### PR TITLE
rsdroid-testing: Diagnose missing Windows lib

### DIFF
--- a/.github/scripts/check_robolectric_assets.sh
+++ b/.github/scripts/check_robolectric_assets.sh
@@ -19,3 +19,13 @@ then
 	echo "Error: Expected 1 .dll file" 
 	exit 1
 fi
+
+# list the libraries
+objdump --private-headers rsdroid.dll  | grep "DLL Name:"
+
+objdump --private-headers rsdroid.dll  | grep "DLL Name:" | grep "libgcc"
+hasGcc=$?
+if [ "$hasGcc" -eq 0  ]
+then
+	echo "[WARN]: libgcc module found. Users will need to install GCC on Windows (#46)"
+fi

--- a/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/RustBackendLoader.java
+++ b/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/RustBackendLoader.java
@@ -53,7 +53,14 @@ public class RustBackendLoader {
             print("loading rsdroid-testing for: " + System.getProperty("os.name"));
 
             if (OS.isFamilyWindows()) {
-                load("rsdroid", ".dll");
+                try {
+                    load("rsdroid", ".dll");
+                } catch (UnsatisfiedLinkError e) {
+                    if (e.getMessage() != null && e.getMessage().contains("Can't find dependent libraries")) {
+                        throw new UnsatisfiedLinkErrorEx("Failed to load library. Please install GCC (https://github.com/david-allison-1/Anki-Android-Backend/issues/46)", e);
+                    }
+                }
+
             } else if (OS.isFamilyMac()) {
                 load("librsdroid", ".dylib");
             } else if (OS.isFamilyUnix()) {

--- a/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/UnsatisfiedLinkErrorEx.java
+++ b/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/UnsatisfiedLinkErrorEx.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid.testing;
+
+public class UnsatisfiedLinkErrorEx extends UnsatisfiedLinkError {
+
+    public UnsatisfiedLinkErrorEx(String s, Throwable cause) {
+        super(s);
+        initCause(cause);
+    }
+}


### PR DESCRIPTION
The rsdroid dll is currently dynamically linked to gcc to allow unwinding. I was unable to find documentation to disable this.

This isn't ideal for Windows consumers, as it requires that they install GCC (specifically: `libgcc_s_seh-1.dll`).

So we inform the user that they need to install GCC - not ideal, but it fixes a blocker

Workaround for issue #46