### PR TITLE
build(deps): refactor dependency management a bit / update POM vars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
 buildscript {
     ext {
         protobufVersion = "3.19.3"
+        appcompatVersion = "1.3.1"
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ buildscript {
     ext {
         protobufVersion = "3.19.3"
         appcompatVersion = "1.3.1"
+        androidxTestJunitVersion = "1.1.3"
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
+    ext {
+        protobufVersion = "3.19.3"
+    }
+
     repositories {
         google()
         jcenter()

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,15 +23,15 @@ VERSION_NAME=0.1.10
 
 POM_INCEPTION_YEAR=2020
 
-POM_URL=https://github.com/david-allison-1/Anki-Android-Backend
-POM_SCM_URL=https://github.com/david-allison-1/Anki-Android-Backend
-POM_SCM_CONNECTION=scm:git:git://github.com/david-allison-1/Anki-Android-Backend.git
-POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/david-allison-1/Anki-Android-Backend.git
+POM_URL=https://github.com/ankidroid/Anki-Android-Backend
+POM_SCM_URL=https://github.com/ankidroid/Anki-Android-Backend
+POM_SCM_CONNECTION=scm:git:git://github.com/ankidroid/Anki-Android-Backend.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ankidroid/Anki-Android-Backend.git
 
 POM_LICENCE_NAME=GNU General Public License (GPL) version 3.0
 POM_LICENCE_URL=https://www.gnu.org/licenses/gpl-3.0.en.html
 POM_LICENCE_DIST=repo
 
-POM_DEVELOPER_ID=david-allison-1
+POM_DEVELOPER_ID=david-allison
 POM_DEVELOPER_NAME=David Allison
-POM_DEVELOPER_URL=https://github.com/david-allison-1/
+POM_DEVELOPER_URL=https://github.com/david-allison/

--- a/rsdroid-instrumented/build.gradle
+++ b/rsdroid-instrumented/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "androidx.appcompat:appcompat:${rootProject.ext.appcompatVersion}"
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation "androidx.test.ext:junit:${rootProject.ext.androidxTestJunitVersion}"
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation project(path: ':rsdroid')
 

--- a/rsdroid-instrumented/build.gradle
+++ b/rsdroid-instrumented/build.gradle
@@ -44,7 +44,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation "androidx.appcompat:appcompat:${rootProject.ext.appcompatVersion}"
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/rsdroid-instrumented/build.gradle
+++ b/rsdroid-instrumented/build.gradle
@@ -18,7 +18,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 30
-    buildToolsVersion "30.0.1"
 
     defaultConfig {
         applicationId "net.ankiweb.rsdroid.instrumented"

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar", '*.so'])
     implementation 'androidx.appcompat:appcompat:1.3.1'
     // Protobuf is part of the ABI, so include it as a compile/api dependency.
-    api 'com.google.protobuf:protobuf-java:3.19.3'
+    api "com.google.protobuf:protobuf-java:${rootProject.ext.protobufVersion}"
     implementation 'androidx.sqlite:sqlite:2.1.0'
     implementation 'com.jakewharton.timber:timber:5.0.1'
 

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.robolectric:robolectric:4.5.1"
     testImplementation 'androidx.test:core:1.4.0'
-    testImplementation 'androidx.test.ext:junit:1.1.3'
+    testImplementation "androidx.test.ext:junit:${rootProject.ext.androidxTestJunitVersion}"
     testImplementation project(path: ':rsdroid-testing')
 
 }

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -16,7 +16,6 @@ def getAnkiCommitHash = { ->
 
 android {
     compileSdkVersion 30
-    buildToolsVersion "30.0.1"
     ndkVersion "22.0.7026061" // Used by GitHub actions - avoids an install step on some machines
 
     compileOptions {

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -59,7 +59,7 @@ apply from: "proto.gradle"
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar", '*.so'])
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation "androidx.appcompat:appcompat:${rootProject.ext.appcompatVersion}"
     // Protobuf is part of the ABI, so include it as a compile/api dependency.
     api "com.google.protobuf:protobuf-java:${rootProject.ext.protobufVersion}"
     implementation 'androidx.sqlite:sqlite:2.1.0'

--- a/rsdroid/proto.gradle
+++ b/rsdroid/proto.gradle
@@ -31,7 +31,7 @@ protobuf {
         anki { path = f.absolutePath }
     }
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.8.0'
+        artifact = "com.google.protobuf:protoc:${rootProject.ext.protobufVersion}"
     }
     generateProtoTasks {
         all().each { task ->


### PR DESCRIPTION

A collection of little commits to extract vars re-used in multiple places, clear a gradle warning and update POM vars

each commit tells a story

When this is in and the gradle update I *think* it'll mostly clear the dependabot gradle dep queue except the maven publish which had breaking changes