### PR TITLE
build(deps): refactor build scripts to use single version references

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         protobufVersion = "3.19.3"
         appcompatVersion = "1.3.1"
         androidxTestJunitVersion = "1.1.3"
+        sqliteVersion = "2.1.0"
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -33,7 +33,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
+        compileSdkVersion = 30
+        targetSdkVersion = 30
+        minSdkVersion = 21
         protobufVersion = "3.19.3"
         appcompatVersion = "1.3.1"
         androidxTestJunitVersion = "1.1.3"

--- a/rsdroid-instrumented/build.gradle
+++ b/rsdroid-instrumented/build.gradle
@@ -17,12 +17,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
         applicationId "net.ankiweb.rsdroid.instrumented"
-        minSdkVersion 21
-        targetSdkVersion 30
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
 

--- a/rsdroid-instrumented/build.gradle
+++ b/rsdroid-instrumented/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation project(path: ':rsdroid')
 
-    androidTestImplementation 'androidx.sqlite:sqlite-framework:2.1.0'
+    androidTestImplementation "androidx.sqlite:sqlite-framework:${rootProject.ext.sqliteVersion}"
 
     androidTestImplementation 'com.jakewharton.timber:timber:5.0.1'
 }

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -15,7 +15,7 @@ def getAnkiCommitHash = { ->
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion rootProject.ext.compileSdkVersion
     ndkVersion "22.0.7026061" // Used by GitHub actions - avoids an install step on some machines
 
     compileOptions {
@@ -24,8 +24,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 30
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName VERSION_NAME
 

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:${rootProject.ext.appcompatVersion}"
     // Protobuf is part of the ABI, so include it as a compile/api dependency.
     api "com.google.protobuf:protobuf-java:${rootProject.ext.protobufVersion}"
-    implementation 'androidx.sqlite:sqlite:2.1.0'
+    implementation "androidx.sqlite:sqlite:${rootProject.ext.sqliteVersion}"
     implementation 'com.jakewharton.timber:timber:5.0.1'
 
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION

This will allow for better control of versions

Specifically, the sqlite dependency had one version but two artifacts, and it needs a higher compileSdkVersion - the combination of these changes should clean that up

And no one should use jcenter anymore