### PR TITLE
build(deps): bump sqlite from 2.1.0 to 2.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         protobufVersion = "3.19.3"
         appcompatVersion = "1.3.1"
         androidxTestJunitVersion = "1.1.3"
-        sqliteVersion = "2.1.0"
+        sqliteVersion = "2.2.0"
     }
 
     repositories {


### PR DESCRIPTION
We want the new version of the sqlite dependency but

...it requires compileSdkVersion 31
...which requires JDK11
...which requires newer Android SDK commandline tools (used to install NDK)

So, 

- switch our NDK github actions install method to [`setup-ndk`](https://github.com/nttld/setup-ndk) - should work
- switch our JDK to 11 in github actions and enforce it
- *then* switch sqlite versions and Android API

Variables are at least extracted so may be modified in one spot See #154 and #153 - possible easily because of #176 