### PR TITLE
build(deps): bump ndk version to r24

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -31,7 +31,7 @@ jobs:
     # COULD_BE_BETTER: Consider turning this into a GitHub action - help the wider community
     # NDK install (unzipping) is really noisy - silence the log spam with grep, while keeping errors
     - name: Install NDK (silent)
-      run: .github/scripts/install_ndk.sh 22.0.7026061
+      run: .github/scripts/install_ndk.sh 24.0.8215888
 
     - name: Install linker
       run: .github/scripts/linux_install_x86_64-unknown-linux-gnu-gcc.sh

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -30,7 +30,7 @@ jobs:
       uses: mikehardy/setup-android@main
 
     - name: Install NDK
-      run: .github/scripts/install_ndk.sh 22.0.7026061
+      run: .github/scripts/install_ndk.sh 24.0.8215888
 
     - name: Test NDK
       run: echo "NDK set to $ANDROID_NDK_HOME"
@@ -115,7 +115,7 @@ jobs:
       uses: mikehardy/setup-android@main
 
     - name: Install NDK
-      run: .github/scripts/install_ndk.sh 22.0.7026061
+      run: .github/scripts/install_ndk.sh 24.0.8215888
 
     - name: run tests
       uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/publish_library.yml
+++ b/.github/workflows/publish_library.yml
@@ -24,7 +24,7 @@ jobs:
       uses: mikehardy/setup-android@main
 
     - name: Install NDK
-      run: .github/scripts/install_ndk.sh 22.0.7026061
+      run: .github/scripts/install_ndk.sh 24.0.8215888
 
     - name: Install linker
       run: .github/scripts/linux_install_x86_64-unknown-linux-gnu-gcc.sh

--- a/.github/workflows/publish_testing.yml
+++ b/.github/workflows/publish_testing.yml
@@ -25,7 +25,7 @@ jobs:
       uses: mikehardy/setup-android@main
 
     - name: Install NDK
-      run: .github/scripts/install_ndk.sh 22.0.7026061
+      run: .github/scripts/install_ndk.sh 24.0.8215888
 
     # install cargo
     - name: Install Rust

--- a/.github/workflows/robolectric_build.yml
+++ b/.github/workflows/robolectric_build.yml
@@ -38,8 +38,8 @@ jobs:
     - name: Install Android Command Line Tools
       uses: mikehardy/setup-android@main
 
-    - name: Install NDK (r22 - 22.0.7026061)
-      run: .github/scripts/install_ndk.sh 22.0.7026061
+    - name: Install NDK
+      run: .github/scripts/install_ndk.sh 24.0.8215888
 
 # TODO: Needs investigation. This seemed to work before adding gnubin/v1, just with serde broken.
 # Now it doesn't seem to be picked up by rust.
@@ -159,13 +159,13 @@ jobs:
 
     - name: Install NDK (silent)
       if: matrix.os != 'windows-latest'
-      run: .github/scripts/install_ndk.sh 22.0.7026061
+      run: .github/scripts/install_ndk.sh 24.0.8215888
 
     - name: Install NDK (Windows - silent)
       if: matrix.os == 'windows-latest'
       run: |
             Write-Host "NDK Install Started"
-            (. sdkmanager.bat --install "ndk;22.0.7026061" --sdk_root="$Env:ANDROID_SDK_ROOT") | out-null
+            (. sdkmanager.bat --install "ndk;24.0.8215888" --sdk_root="$Env:ANDROID_SDK_ROOT") | out-null
             Write-Host "NDK Install Completed"
 
     - name: Install Python Setuptools

--- a/.github/workflows/update_gradle_wrapper.yml
+++ b/.github/workflows/update_gradle_wrapper.yml
@@ -30,7 +30,7 @@ jobs:
       # COULD_BE_BETTER: Consider turning this into a GitHub action - help the wider community
       # NDK install (unzipping) is really noisy - silence the log spam with grep, while keeping errors
       - name: Install NDK (silent)
-        run: .github/scripts/install_ndk.sh 22.0.7026061
+        run: .github/scripts/install_ndk.sh 24.0.8215888
 
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -32,7 +32,7 @@ jobs:
             Write-Host "NDK Install Started"
             Write-Host "ANDROID_HOME - $Env:ANDROID_HOME"
             Write-Host "ANDROID_SDK_ROOT - $Env:ANDROID_SDK_ROOT"
-            (. sdkmanager.bat --install "ndk;22.0.7026061" --sdk_root="$Env:ANDROID_SDK_ROOT") | out-null
+            (. sdkmanager.bat --install "ndk;24.0.8215888" --sdk_root="$Env:ANDROID_SDK_ROOT") | out-null
             Write-Host "NDK Install Completed"
 
     # bzip2-sys does not build when the value of CC_armv7-linux-androideabi contains a space

--- a/.github/workflows/windows_pure_build.yml
+++ b/.github/workflows/windows_pure_build.yml
@@ -30,7 +30,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: |
         Write-Host "NDK Install Started"
-        (. sdkmanager.bat --install "ndk;22.0.7026061" --sdk_root="$Env:ANDROID_SDK_ROOT") | out-null
+        (. sdkmanager.bat --install "ndk;24.0.8215888" --sdk_root="$Env:ANDROID_SDK_ROOT") | out-null
         Write-Host "NDK Install Completed"
 
     - name: Install Rust

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -35,7 +35,7 @@ For example:
 ```groovy
     compileSdkVersion 30
     buildToolsVersion "30.0.1"
-    ndkVersion "22.0.7026061" // Used by GitHub actions - avoids an install step on some machines
+    ndkVersion "24.0.8215888" // Used by GitHub actions - avoids an install step on some machines
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -50,7 +50,7 @@ For example:
 That indicates you need:
 
 - SDK 30 installed (compileSdkVersion and targetSdkVersion)
-- NDK 22.0.7026062 (ndkVersion)
+- NDK 24.0.8215888 (ndkVersion)
 - Build Tools 30.0.1 (buildToolsVersion)
 
 You should open Android Studio and use the Tools --> SDK Manager to download them

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -16,7 +16,7 @@ def getAnkiCommitHash = { ->
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    ndkVersion "22.0.7026061" // Used by GitHub actions - avoids an install step on some machines
+    ndkVersion "24.0.8215888" // Used by GitHub actions - avoids an install step on some machines
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/tools/doctor.sh
+++ b/tools/doctor.sh
@@ -2,7 +2,7 @@
 
 set -e # Error out if there were any problems
 
-ANDROID_NDK_VERSION="22.0.7026061"
+ANDROID_NDK_VERSION="24.0.8215888"
 
 red=31
 green=32


### PR DESCRIPTION
This is the current latest stable version. r23 is LTS, r25 is at beta2

Related #179

This is speculative. It might work. It might not. I'm going to trust CI on it though after the work I've put in on CI just now...

I won't be surprised if this also needs some other chunks of toolchain updated like perhaps build tools, or if it flags new warnings in code and generates some set-warnings-as-errors / fix warnings/errors work. We'll see...