### PR TITLE
build(deps): switch back to upstream setup-android

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -26,7 +26,7 @@ jobs:
         java-version: "11" # minimum for Android API31
 
     - name: Install Android Command Line Tools
-      uses: mikehardy/setup-android@main
+      uses: android-actions/setup-android@v2
 
     # COULD_BE_BETTER: Consider turning this into a GitHub action - help the wider community
     # NDK install (unzipping) is really noisy - silence the log spam with grep, while keeping errors

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -27,7 +27,7 @@ jobs:
         java-version: "11" # minimum for Android API31
 
     - name: Install Android Command Line Tools
-      uses: mikehardy/setup-android@main
+      uses: android-actions/setup-android@v2
 
     - name: Install NDK
       run: .github/scripts/install_ndk.sh 22.0.7026061
@@ -112,7 +112,7 @@ jobs:
         java-version: "11" # minimum for Android API31
 
     - name: Install Android Command Line Tools
-      uses: mikehardy/setup-android@main
+      uses: android-actions/setup-android@v2
 
     - name: Install NDK
       run: .github/scripts/install_ndk.sh 22.0.7026061

--- a/.github/workflows/publish_library.yml
+++ b/.github/workflows/publish_library.yml
@@ -21,7 +21,7 @@ jobs:
         java-version: "11" # minimum for Android API31
 
     - name: Install Android Command Line Tools
-      uses: mikehardy/setup-android@main
+      uses: android-actions/setup-android@v2
 
     - name: Install NDK
       run: .github/scripts/install_ndk.sh 22.0.7026061

--- a/.github/workflows/publish_testing.yml
+++ b/.github/workflows/publish_testing.yml
@@ -22,7 +22,7 @@ jobs:
         java-version: "11" # minimum for Android API31
 
     - name: Install Android Command Line Tools
-      uses: mikehardy/setup-android@main
+      uses: android-actions/setup-android@v2
 
     - name: Install NDK
       run: .github/scripts/install_ndk.sh 22.0.7026061

--- a/.github/workflows/robolectric_build.yml
+++ b/.github/workflows/robolectric_build.yml
@@ -36,7 +36,7 @@ jobs:
         java-version: "11" # minimum for Android API31
 
     - name: Install Android Command Line Tools
-      uses: mikehardy/setup-android@main
+      uses: android-actions/setup-android@v2
 
     - name: Install NDK (r22 - 22.0.7026061)
       run: .github/scripts/install_ndk.sh 22.0.7026061
@@ -155,7 +155,7 @@ jobs:
         java-version: "11" # minimum for Android API31
 
     - name: Install Android Command Line Tools
-      uses: mikehardy/setup-android@main
+      uses: android-actions/setup-android@v2
 
     - name: Install NDK (silent)
       if: matrix.os != 'windows-latest'

--- a/.github/workflows/update_gradle_wrapper.yml
+++ b/.github/workflows/update_gradle_wrapper.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: "11" # minimum for Android API31
 
       - name: Install Android Command Line Tools
-        uses: mikehardy/setup-android@main
+      uses: android-actions/setup-android@v2
 
       # COULD_BE_BETTER: Consider turning this into a GitHub action - help the wider community
       # NDK install (unzipping) is really noisy - silence the log spam with grep, while keeping errors

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -24,7 +24,7 @@ jobs:
         java-version: "11" # minimum for Android API31
 
     - name: Install Android Command Line Tools
-      uses: mikehardy/setup-android@main
+      uses: android-actions/setup-android@v2
 
       # TODO: Ignore lines like we do in the Unix scripts, rather than all of them
     - name: Install NDK (silent)

--- a/.github/workflows/windows_pure_build.yml
+++ b/.github/workflows/windows_pure_build.yml
@@ -24,7 +24,7 @@ jobs:
         java-version: "11" # minimum for Android API31
 
     - name: Install Android Command Line Tools
-      uses: mikehardy/setup-android@main
+      uses: android-actions/setup-android@v2
 
     - name: Install NDK (Windows - silent)
       if: matrix.os == 'windows-latest'


### PR DESCRIPTION
This was originally to bring in a more up-to-date command-line tools, fixing
the bundled sdkmanager's problems with JDK11. The best action in the community
was not quite up to date so I made a local change, but now the PR is merged and released,
so back to upstream, excellent

See https://github.com/android-actions/setup-android/pull/272