### PR TITLE
build(deps): point anki submodule to ankidroid org fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "anki"]
 	path = rslib-bridge/anki
-	url = https://github.com/david-allison-1/anki
+	url = https://github.com/ankidroid/anki
 	branch = ankidroid-2-1-34


### PR DESCRIPTION
You will need to do these things to take advantage of this if you
have a local checkout already. All commands performed from repo root:

rm -rf .git/modules/anki
rm -rf rslib-bridge/anki
git submodule sync
git submodule update

A clean checkout will work assuming you follow procedure to checkout / init
submodules during checkout as documented for the repo

https://stackoverflow.com/questions/14404704/how-do-i-replace-a-git-submodule-with-another-repo/14405542#14405542