### PR TITLE
Declare backend methods with @CheckResult

### DIFF
--- a/rsdroid/proguard-rules.pro
+++ b/rsdroid/proguard-rules.pro
@@ -19,3 +19,5 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+-keepattributes Exceptions,InnerClasses,Signature,Deprecated,
+                SourceFile,LineNumberTable,*Annotation*,EnclosingMethod

--- a/tools/protoc-gen/protoc-gen.py
+++ b/tools/protoc-gen/protoc-gen.py
@@ -112,7 +112,7 @@ class Message:
             name = "`val`"
 
         return "{}: {}{}".format(
-           name, to_java_type(field.type, field), annotation, 
+           name, to_java_type(field.type, field), annotation,
         )
 
     def as_setter_name(self, field):
@@ -249,9 +249,11 @@ fun {name}Raw(input: ByteArray): ByteArray {{
             return_segment = f"""
 {name}Raw(input.toByteArray());
             """
+            check = ""
             out_with_colon = ""
         else:
             out_with_colon = f": {out}"
+            check = "@CheckResult"
             return_segment = f"""\
 try {{
     return {output_type_name}.parseFrom({name}Raw(input.toByteArray())){single_attribute};
@@ -260,6 +262,7 @@ try {{
 }}"""
 
         buf += f"""
+{check}
 @Throws(BackendException::class)
 open fun {name}{inv}{out_with_colon} {{
     {deser}
@@ -316,6 +319,8 @@ def generate_code(request, response):
 @file:Suppress("NAME_SHADOWING")
 
 package anki.backend;
+
+import androidx.annotation.CheckResult;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.GeneratedMessageV3;


### PR DESCRIPTION
This currently doesn't seem to work - when viewing the decompiled class file in the AnkiDroid repo or hovering over a backend method, it shows the annotation has been included, but for some reason it is ineffective: it does not trigger a lint error, and the IDE does not show a warning. Any ideas?