### PR TITLE
Fix syncing with legacy_schema = false

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison-1
-VERSION_NAME=0.1.16-anki2.1.55
+VERSION_NAME=0.1.17-anki2.1.55
 
 POM_INCEPTION_YEAR=2020
 

--- a/rslib-bridge/Cargo.toml
+++ b/rslib-bridge/Cargo.toml
@@ -9,7 +9,7 @@ crate_type = ["dylib"]
 
 [dependencies]
 jni = { version = "0.17.0", default-features = false }
-anki = { path = "../anki/rslib" }
+anki = { path = "../anki/rslib", features = ["rustls"] }
 prost = "0.11"
 serde = "1.0.114"
 serde_json = "1.0.56"


### PR DESCRIPTION
Sorry Mike, unfortunately SSL support was missing from the 0.1.16 release, meaning users will not be able to sync with legacy_schema=false. To avoid problems for alpha testers, it might be a good idea to either:

a) do another release (and then bump the version in the AnkiDroid) before the next alpha build, or
b) revert the two commits to the AnkiDroid repo until you're ready to make another backend release
