### PR TITLE
Fix incorrect timezone on some devices; bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,15 +81,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,11 +364,11 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
- "iana-time-zone",
+ "libc",
  "num-integer",
  "num-traits",
  "winapi",
@@ -1210,19 +1201,6 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "js-sys",
- "wasm-bindgen",
- "winapi",
 ]
 
 [[package]]

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison-1
-VERSION_NAME=0.1.17-anki2.1.55
+VERSION_NAME=0.1.18-anki2.1.55
 
 POM_INCEPTION_YEAR=2020
 


### PR DESCRIPTION
The timezone dependency Anki uses recently changed the way they gather timezone info. They used to rely on a libc call, which could cause crashes if env vars happened to be modified in another thread at the same, so they decided to reimplement the functionality in Rust instead to address a CVE: https://github.com/chronotope/chrono/issues/602

Android appeared to be supported (https://github.com/chronotope/chrono/releases/tag/v0.4.21), but it seems that this only applies to some devices, or was not tested. On a Pixel 2/API 31 sim, the /system/usr/share/zoneinfo path it refers to exists, but it does not have the individual timezone files that the library expects to find.

Until a better solution can be found, this commit reverts to an earlier version of the library where TZ lookup was working. It depends on https://github.com/ankidroid/anki/pull/7

Edit: issue reported on https://github.com/chronotope/chrono/issues/922