### PR TITLE
Switch submodule to Anki repo; bump version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "anki"]
 	path = anki
-	url = https://github.com/ankidroid/anki
+	url = https://github.com/ankitects/anki

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,7 @@ version = "0.0.0"
 dependencies = [
  "ammonia",
  "anki_i18n",
+ "ascii_percent_encoding",
  "async-trait",
  "blake3",
  "bytes",
@@ -117,7 +118,6 @@ dependencies = [
  "num_cpus",
  "num_enum",
  "once_cell",
- "pct-str",
  "pin-project",
  "prost",
  "prost-build",
@@ -134,15 +134,14 @@ dependencies = [
  "serde_repr",
  "serde_tuple",
  "sha1",
- "slog",
- "slog-async",
- "slog-envlogger",
- "slog-term",
  "snafu",
  "strum",
  "tempfile",
  "tokio",
  "tokio-util",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "unic-ucd-category",
  "unicase",
  "unicode-normalization",
@@ -177,12 +176,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
-name = "arc-swap"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +192,10 @@ name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "ascii_percent_encoding"
+version = "0.0.0"
 
 [[package]]
 name = "async-trait"
@@ -371,6 +368,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "time 0.1.45",
  "winapi",
 ]
 
@@ -439,7 +437,7 @@ checksum = "454038500439e141804c655b4cd1bc6a70bcb95cd2bc9463af5661b6956f0e46"
 dependencies = [
  "libc",
  "once_cell",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -628,27 +626,6 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -989,7 +966,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1436,6 +1413,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,7 +1490,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.36.1",
 ]
 
@@ -1546,6 +1532,16 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -1696,6 +1692,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,14 +1741,6 @@ dependencies = [
  "hmac",
  "password-hash",
  "sha2",
-]
-
-[[package]]
-name = "pct-str"
-version = "1.1.0"
-source = "git+https://github.com/timothee-haudebourg/pct-str.git?rev=4adccd8d4a222ab2672350a102f06ae832a0572d#4adccd8d4a222ab2672350a102f06ae832a0572d"
-dependencies = [
- "utf8-decode",
 ]
 
 [[package]]
@@ -1971,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e330bf1316db56b12c2bcfa399e8edddd4821965ea25ddb2c134b610b1c1c604"
+checksum = "276470f7f281b0ed53d2ae42dd52b4a8d08853a3c70e7fe95882acbb98a6ae94"
 dependencies = [
  "bytes",
  "heck",
@@ -2099,17 +2093,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall",
- "thiserror",
-]
-
-[[package]]
 name = "regex"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2125,6 +2108,9 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
@@ -2204,6 +2190,7 @@ version = "0.1.0"
 dependencies = [
  "android_logger",
  "anki",
+ "chrono",
  "gag",
  "itertools",
  "jni",
@@ -2211,13 +2198,13 @@ dependencies = [
  "lexical-core",
  "log",
  "num_enum",
+ "once_cell",
  "prost",
  "rusqlite",
  "serde",
  "serde_derive",
  "serde_json",
- "slog",
- "slog-envlogger",
+ "tracing",
 ]
 
 [[package]]
@@ -2470,6 +2457,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,74 +2487,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "slog"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
-
-[[package]]
-name = "slog-async"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "766c59b252e62a34651412870ff55d8c4e6d04df19b43eecb2703e417b097ffe"
-dependencies = [
- "crossbeam-channel",
- "slog",
- "take_mut",
- "thread_local",
-]
-
-[[package]]
-name = "slog-envlogger"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "906a1a0bc43fed692df4b82a5e2fbfc3733db8dad8bb514ab27a4f23ad04f5c0"
-dependencies = [
- "log",
- "regex",
- "slog",
- "slog-async",
- "slog-scope",
- "slog-stdlog",
- "slog-term",
-]
-
-[[package]]
-name = "slog-scope"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f95a4b4c3274cd2869549da82b57ccc930859bdbf5bcea0424bc5f140b3c786"
-dependencies = [
- "arc-swap",
- "lazy_static",
- "slog",
-]
-
-[[package]]
-name = "slog-stdlog"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6706b2ace5bbae7291d3f8d2473e2bfab073ccd7d03670946197aec98471fa3e"
-dependencies = [
- "log",
- "slog",
- "slog-scope",
-]
-
-[[package]]
-name = "slog-term"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87d29185c55b7b258b4f120eab00f48557d4d9bc814f41713f449d35b0f8977c"
-dependencies = [
- "atty",
- "slog",
- "term",
- "thread_local",
- "time",
 ]
 
 [[package]]
@@ -2684,12 +2612,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "take_mut"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
-
-[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2712,17 +2634,6 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
-]
-
-[[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
 ]
 
 [[package]]
@@ -2767,6 +2678,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -2933,22 +2855,76 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.29"
+name = "tracing-appender"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time 0.3.17",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3124,12 +3100,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "utf8-decode"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca61eb27fa339aa08826a29f03e87b99b4d8f0fc2255306fd266bb1b6a9de498"
-
-[[package]]
 name = "utime"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3138,6 +3108,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -3171,6 +3147,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -3453,7 +3435,7 @@ dependencies = [
  "sha2",
  "snafu",
  "syn",
- "time",
+ "time 0.3.17",
  "time-macros",
  "tokio",
  "url",
@@ -3479,7 +3461,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time",
+ "time 0.3.17",
  "zstd 0.11.2+zstd.1.5.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,9 +2753,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.22.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2768,7 +2768,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison-1
-VERSION_NAME=0.1.18-anki2.1.55
+VERSION_NAME=0.1.19-anki2.1.56pre
 
 POM_INCEPTION_YEAR=2020
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison-1
-VERSION_NAME=0.1.19-anki2.1.56pre
+VERSION_NAME=0.1.19-anki2.1.56
 
 POM_INCEPTION_YEAR=2020
 

--- a/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/ExceptionTest.java
+++ b/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/ExceptionTest.java
@@ -81,7 +81,6 @@ public class ExceptionTest {
             { BackendForTesting.ErrorType.NetworkError, BackendNetworkException.class},
             { BackendForTesting.ErrorType.FilteredDeckError, BackendDeckIsFilteredException.class },
             { BackendForTesting.ErrorType.Existing, BackendExistingException.class },
-            { BackendForTesting.ErrorType.FatalError, BackendException.BackendFatalError.class },
             { BackendForTesting.ErrorType.Interrupted, BackendInterruptedException.class},
             { BackendForTesting.ErrorType.InvalidInput, BackendInvalidInputException.class},
             { BackendForTesting.ErrorType.JSONError, BackendJsonException.class },

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/Backend.kt
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/Backend.kt
@@ -58,7 +58,7 @@ open class Backend(val context: Context, langs: Iterable<String> = listOf("en"),
                     collectionPath.replace(".anki2", ".media.db"))
         }
         checkMainThreadOp()
-        openCollection(collectionPath, mediaFolder, mediaDb, "", legacySchema)
+        openCollection(collectionPath, mediaFolder, mediaDb, legacySchema)
     }
 
     /** Forces a full media check on next sync. Only valid with new backend. */
@@ -104,9 +104,9 @@ open class Backend(val context: Context, langs: Iterable<String> = listOf("en"),
     /**
      * Open a collection. There must not already be an open collection.
      */
-    override fun openCollection(collectionPath: String, mediaFolderPath: String, mediaDbPath: String, logPath: String, forceSchema11: Boolean) {
+    override fun openCollection(collectionPath: String, mediaFolderPath: String, mediaDbPath: String, forceSchema11: Boolean) {
         try {
-            super.openCollection(collectionPath, mediaFolderPath, mediaDbPath, logPath, forceSchema11)
+            super.openCollection(collectionPath, mediaFolderPath, mediaDbPath, forceSchema11)
         } catch (exc: BackendException.BackendDbException) {
             throw exc.toSQLiteException("db open")
         }

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendException.kt
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendException.kt
@@ -105,7 +105,7 @@ open class BackendException : RuntimeException {
                 BackendError.Kind.JSON_ERROR -> return BackendJsonException(error)
                 BackendError.Kind.SYNC_AUTH_ERROR -> return BackendSyncAuthFailedException(error)
                 BackendError.Kind.SYNC_OTHER_ERROR -> return BackendSyncException(error)
-                BackendError.Kind.FATAL_ERROR -> return BackendFatalError(error)
+                BackendError.Kind.ANKIDROID_PANIC_ERROR -> return BackendFatalError(error)
                 BackendError.Kind.EXISTS -> return BackendExistingException(error)
                 BackendError.Kind.FILTERED_DECK_ERROR -> return BackendDeckIsFilteredException(error)
                 BackendError.Kind.INTERRUPTED -> return BackendInterruptedException(error)

--- a/rsdroid/src/test/java/net/ankiweb/CollectionCreationTest.java
+++ b/rsdroid/src/test/java/net/ankiweb/CollectionCreationTest.java
@@ -31,7 +31,7 @@ public class CollectionCreationTest {
 
     @Before
     public void loadLibrary() {
-        RustBackendLoader.ensureSetup(null);
+        RustBackendLoader.ensureSetup();
     }
 
     @Test

--- a/rslib-bridge/.rustfmt.toml
+++ b/rslib-bridge/.rustfmt.toml
@@ -1,0 +1,6 @@
+# this is not supported on stable Rust, and is ignored by the Bazel rules; it is only
+# useful for manual invocation with 'cargo +nightly fmt'
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+# imports_granularity = "Item"
+# imports_layout = "Vertical"

--- a/rslib-bridge/Cargo.toml
+++ b/rslib-bridge/Cargo.toml
@@ -10,6 +10,9 @@ crate_type = ["dylib"]
 [dependencies]
 jni = { version = "0.17.0", default-features = false }
 anki = { path = "../anki/rslib", features = ["rustls"] }
+# pinned until https://github.com/chronotope/chrono/issues/922 is resolved
+chrono = "=0.4.19"
+
 prost = "0.11"
 serde = "1.0.114"
 serde_json = "1.0.56"
@@ -21,6 +24,6 @@ lexical-core = "0.7.5"
 rusqlite = { version = "0.28.0", features = ["trace", "functions", "collation", "bundled"] }
 android_logger = "0.11.0"
 log = "0.4.17"
-slog = "2.7.0"
 gag = "1.0.0"
-slog-envlogger = "2.2.0"
+once_cell = "1.16.0"
+tracing = { version = "0.1.37", features = ["max_level_trace", "release_max_level_debug", "log"] }


### PR DESCRIPTION
As of https://github.com/ankitects/anki/commit/0eddb25287264fd9bd6beab09df691e4afb5f370, the AnkiDroid-specific patches atop the desktop repo have been merged into the desktop repo, so the anki submodule in this repo can now point directly to the main branch of the desktop code, and updating to newer desktop code just requires bumping the commit ref in the submodule here.

~No significant changes to the Rust code are expected before a 2.1.56 release, but I've added 'pre' to the version number to reflect that it's not pointing to an official release tag.~

Other changes:
- The desktop switched to a different logging library, which meant some changes here were required.
- The "fatal error" synthesis test been removed, as the PR above removed that AnkiDroid-specific error from Anki's standard error type, meaning it can't be easily synthesized from the backend method (the error is created by code in this repo, not in that repo, so mock errors need to be generated in this repo if desired in the future).