### PR TITLE
fix(anki): bump anki commit hash to 2.1.60 tag sha

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install Xcode/Visual Studio if on macOS/Windows.
 
 ### Rust
 
-Install rustup from https://rustup.rs/
+Install rustup from <https://rustup.rs/>
 
 ### Ninja
 
@@ -39,7 +39,7 @@ Windows if using choco:
 
   choco install ninja
 
-You can alternatively download a binary from https://github.com/ninja-build/ninja/releases
+You can alternatively download a binary from <https://github.com/ninja-build/ninja/releases>
 and put it on your path.
 
 ### NDK
@@ -58,7 +58,7 @@ Install [msys2](https://www.msys2.org/) into the default folder location.
 After installation completes, run msys2, and run the following command:
 
 ```
-$ pacman -S git rsync
+pacman -S git rsync
 ```
 
 When following the build steps below, make sure msys is on the path:
@@ -123,7 +123,6 @@ Assuming success, then build the .jar file:
 ./build-robo.sh
 ```
 
-
 ## Modify AnkiDroid to use built library
 
 Now open the AnkiDroid project in AndroidStudio. To tell gradle to load the
@@ -155,7 +154,7 @@ of devices. See .github/workflows for how this is done.
 
 ## Architecture
 
-See (ARCHITECTURE.md)[./docs/ARCHITECTURE.md]
+See [ARCHITECTURE.md](./docs/ARCHITECTURE.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ Only the current platform is built by default. In CI, the .aar and .jar files
 are built for multiple platforms, so one release library can be used on a variety
 of devices. See .github/workflows for how this is done.
 
+### Creating and Publishing a release
+
+1. Most likely you will want to align the `anki` submodule SHA with a new tagged release from upstream `ankitects/anki` repository
+1. Edit the file `gradle.properties` - increment the Anki-Android-Backend version (first part of version string) if there are code changes in this repository, and align the second part of the version string (the anki upstream part) with the tag name of the upstream tag used for the anki submodule SHA here
+1. Run the Github workflow `Build AAR and Robo (all platforms)` manually with a string argument (I typically use `shipit`, but any string will work) - this will trigger a full release build ready for upload to maven
+1. Check the workflow logs for the link to Maven Central where **if you have a Maven Central user with permissions (like David A and Mike H - ask if you want permission)** you may "close" the repository" then after a short wait "release" the repository
+1. Head over to the main `Anki-Android` repository and update the `AnkiDroid/build.gradle` file there to adopt the new backend version once it shows up in [https://repo1.maven.org/maven2/io/github/david-allison-1/anki-android-backend/]
+
 ## Architecture
 
 See [ARCHITECTURE.md](./docs/ARCHITECTURE.md)

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison-1
-VERSION_NAME=0.1.21-anki2.1.58
+VERSION_NAME=0.1.21-anki2.1.60
 
 POM_INCEPTION_YEAR=2020
 


### PR DESCRIPTION
I *believe* pending review that all I need to do to adopt a new upstream anki version now is switch the submodule sha to the new commit reference - if so, this is the PR that does that for anki 2.1.60

Note: this is an experiment to see if I can gain self-sufficiency in this area, I don't believe 2.1.60 is vital for AnkiDroid but the low-importance is a feature for this experiment