### PR TITLE
fix: adopt new publishing plugin config requirements

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -89,20 +89,20 @@ jobs:
       - name: Publish AAR to Maven
         if: "${{ github.event.inputs.mavenPublish != '' && github.event_name == 'workflow_dispatch'}}"       
         env:
-          ORG_GRADLE_PROJECT_SIGNING_PRIVATE_KEY: ${{ secrets.SIGNING_PRIVATE_KEY }}
-          ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-          SONATYPE_NEXUS_USERNAME: david-allison-1
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: david-allison-1
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
         run: |
-          ./gradlew rsdroid:uploadArchives -DtestBuildType=release -Dorg.gradle.daemon=false -Dorg.gradle.console=plain
+          ./gradlew rsdroid:publishAllPublicationsToMavenCentral -DtestBuildType=release -Dorg.gradle.daemon=false -Dorg.gradle.console=plain
 
       - name: Publish JAR to Maven
         if: "${{ github.event.inputs.mavenPublish != '' && github.event_name == 'workflow_dispatch'}}"       
         env:
-          ORG_GRADLE_PROJECT_SIGNING_PRIVATE_KEY: ${{ secrets.SIGNING_PRIVATE_KEY }}
-          ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-          SONATYPE_NEXUS_USERNAME: david-allison-1
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: david-allison-1
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
         run: |
           export ANKIDROID_LINUX_CC=x86_64-unknown-linux-gnu-gcc
           export ANKIDROID_MACOS_CC=cc
@@ -110,8 +110,4 @@ jobs:
           export RUST_BACKTRACE=1
           export RUST_LOG=trace
           export NO_CROSS=true
-          ./gradlew rsdroid-testing:uploadArchives -Dorg.gradle.project.macCC=$ANKIDROID_MACOS_CC -DtestBuildType=debug -Dorg.gradle.daemon=false -Dorg.gradle.console=plain
-
-      - name: ℹ️Additional Release Instructions (requires human interaction)
-        if: "${{ github.event.inputs.mavenPublish != '' && github.event_name == 'workflow_dispatch'}}"       
-        run: echo "Sign in to https://oss.sonatype.org/#stagingRepositories , close the repository, then release it"
+          ./gradlew rsdroid-testing:publishAllPublicationsToMavenCentral -Dorg.gradle.project.macCC=$ANKIDROID_MACOS_CC -DtestBuildType=debug -Dorg.gradle.daemon=false -Dorg.gradle.console=plain

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.25.2'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.25.3'
     }
 }
 

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -96,6 +96,12 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     }
 }
 
+mavenPublishing {
+    publishToMavenCentral("DEFAULT", true)
+    // publishToMavenCentral("S01") for publishing through s01.oss.sonatype.org
+    signAllPublications()
+}
+
 signing {
     def hasPrivate = project.hasProperty('SIGNING_PRIVATE_KEY')
     def hasPassword = project.hasProperty('SIGNING_PASSWORD')


### PR DESCRIPTION
the publishing plugin we use has a number of breaking changes in its current version (0.25.3) versus the previous version we used (0.14.2)

- we need to use new environment variables (version 0.15.0)
- we need to use a new target to publish (version 0.17.0)
- we need to add maven central and signing explicitly (version 0.21.0)
- we no longer need to close the repository (automatic if releasing, in 0.22.0)
- we may release the repository w/new config param (available in 0.22.0)

Fixes #298