### PR TITLE
adopt new publishing DSL for rsdroid-testing to match rsdroid

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ export ANDROID_NDK_HOME=$HOME/Library/Android/sdk/ndk/25.2.9519653
 Or Windows using Powershell:
 
 ```
-$env:ANDROID_NDK_HOME="env:ANDROID_SDK_ROOT\ndk\25.2.9519653"
+$env:ANDROID_NDK_HOME="$env:ANDROID_SDK_ROOT\ndk\25.2.9519653"
 ```
 If you don't have Java installed, you may be able to use the version bundled
 with Android Studio. Eg on macOS:

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison-1
-VERSION_NAME=0.1.22-anki2.1.66
+VERSION_NAME=0.1.23-anki2.1.66
 
 POM_INCEPTION_YEAR=2020
 

--- a/rsdroid-testing/build.gradle
+++ b/rsdroid-testing/build.gradle
@@ -49,6 +49,12 @@ jar {
 sourceCompatibility JavaVersion.VERSION_11
 targetCompatibility JavaVersion.VERSION_11
 
+mavenPublishing {
+    publishToMavenCentral("DEFAULT", true)
+    // publishToMavenCentral("S01") for publishing through s01.oss.sonatype.org
+    signAllPublications()
+}
+
 signing {
     def hasPrivate = project.hasProperty('SIGNING_PRIVATE_KEY')
     def hasPassword = project.hasProperty('SIGNING_PASSWORD')


### PR DESCRIPTION

The previous change appeared to work well with regard to the rsdroid module, however I forgot that the rsdroid-testing module has a separate build file and needs the newly-required publishing DSL as well

Hopefully this solves it too

Incidental fix to the docs, and a bump to the module version so we may run the full publish again and hopefully see it go green this time 🤞 

Fixes #298 