### PR TITLE
Improve ci caching

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -72,6 +72,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-debug-v6
 
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        timeout-minutes: 5
+        with:
+          # Only write to the cache for builds on the 'main' branches, stops branches evicting main cache
+          # Builds on other branches will only read from main branch cache writes
+          # Comment this and the with: above out for performance testing on a branch
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          gradle-home-cache-cleanup: true
+
       - name: Build all (current platform)
         run: cargo run -p build_rust
 

--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -42,8 +42,8 @@ jobs:
           distribution: "adopt"
           java-version: "17" # matches Anki-Android
 
-      - name: Rust Cache (Windows)
-        uses: actions/cache@v3
+      - name: Restore Rust Cache (Windows)
+        uses: actions/cache/restore@v3
         if: matrix.os == 'windows-latest'
         with:
           path: |
@@ -57,8 +57,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-debug-v7
 
-      - name: Rust Cache (Unix)
-        uses: actions/cache@v3
+      - name: Restore Rust Cache (Unix)
+        uses: actions/cache/restore@v3
         if: matrix.os != 'windows-latest'
         with:
           path: |
@@ -103,3 +103,29 @@ jobs:
           name: rsdroid-robo-${{ matrix.os }}
           if-no-files-found: error
           path: rsdroid-testing/build/libs
+
+      - name: Save Rust Cache (Windows)
+        uses: actions/cache/save@v3
+        if: matrix.os == 'windows-latest' && github.ref == 'refs/heads/main'
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+            anki/out/rust
+            anki/out/download
+            # no node_modules, as it doesn't unpack properly
+          key: ${{ runner.os }}-rust-debug-v7-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
+
+      - name: Save Rust Cache (Unix)
+        uses: actions/cache/save@v3
+        if: matrix.os != 'windows-latest' && github.ref == 'refs/heads/main'
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+            anki/out/rust
+            anki/out/download
+            anki/out/node_modules
+          key: ${{ runner.os }}-rust-debug-v6-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -54,8 +54,8 @@ jobs:
           brew install x86_64-unknown-linux-gnu
           x86_64-unknown-linux-gnu-gcc -v
 
-      - name: Rust Cache
-        uses: actions/cache@v3
+      - name: Restore Rust Cache
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/.cargo/registry
@@ -111,3 +111,16 @@ jobs:
           export RUST_LOG=trace
           export NO_CROSS=true
           ./gradlew rsdroid-testing:publishAllPublicationsToMavenCentral -Dorg.gradle.project.macCC=$ANKIDROID_MACOS_CC -DtestBuildType=debug -Dorg.gradle.daemon=false -Dorg.gradle.console=plain
+
+      - name: Save Rust Cache
+        uses: actions/cache/save@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+            anki/out/rust
+            anki/out/download
+            anki/out/node_modules
+          key: ${{ runner.os }}-rust-release-v6-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -68,6 +68,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-release-v6
 
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        timeout-minutes: 5
+        with:
+          # Only write to the cache for builds on the 'main' branches, stops branches evicting main cache
+          # Builds on other branches will only read from main branch cache writes
+          # Comment this and the with: above out for performance testing on a branch
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          gradle-home-cache-cleanup: true
+
       - name: Build all
         run: ./build.sh
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -63,7 +63,8 @@ jobs:
             target
             anki/out/rust
             anki/out/extracted
-          key: ${{ runner.os }}-rust-release-v6-${{ hashFiles('Cargo.lock') }}
+            anki/out/node_modules
+          key: ${{ runner.os }}-rust-release-v6-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-rust-release-v6
 


### PR DESCRIPTION
CI is still pretty slow here on the backend repo, and I think the current two biggest items are:

- cache eviction is rapid + unwanted (seen by looking at caches for the repo - https://github.com/ankidroid/Anki-Android-Backend/actions/caches)
- nothing about java work is cached

So strategy here is to only save caches when building on main, and to add caching for gradle work. This should be a big help because caches are scoped by key+branch, so storing enormous branch caches is evicting the main cache (useful for everyone, normally) with branch caches which are not useful on main and not useful on other branches

If this works, we should see cache restores (or attempted restores) in the CI runs here for the current key with hashes plus the backup restore keys, and we should *not* see caching saves in these runs pre-merge because they are not on main.

Then post-merge we should see cache saves.

Incidentally, you can use this page to purge caches now, it's not the newest feature in github but it is relatively new: https://github.com/ankidroid/Anki-Android-Backend/actions/caches

That saves you from having to bump version-strings in cache keys normally, although that's a useful strategy as well