### PR TITLE
Propagate deprecation annotation from Java to Kotlin

### DIFF
--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/database/AnkiDatabaseCursor.kt
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/database/AnkiDatabaseCursor.kt
@@ -67,6 +67,7 @@ abstract class AnkiDatabaseCursor : Cursor {
         throw NotImplementedException()
     }
 
+    @Deprecated("Deprecated in Java")
     override fun deactivate() {
         Timber.w("deactivate - not implemented - throwing")
         throw NotImplementedException()
@@ -76,6 +77,7 @@ abstract class AnkiDatabaseCursor : Cursor {
         throw NotImplementedException()
     }
 
+    @Deprecated("Deprecated in Java")
     override fun requery(): Boolean {
         Timber.w("requery - not implemented - throwing")
         throw NotImplementedException()


### PR DESCRIPTION
Suggested by Kotlin automated tool for Kotlin migration

tested locally, and as you'd expect from such a trivial annotation-only diff, it worked just fine.