### PR TITLE
test(ci): only run CI on push to main

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -1,10 +1,14 @@
 name: Build quick (each platform)
 on:
   workflow_dispatch:
-  push:
   schedule:
     - cron: "0 0 * * *"
   pull_request:
+    branches:
+      - '**'
+  push:
+    branches:
+      - main
 
 env:
   DEBUG: 1

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -6,10 +6,14 @@ on:
         description: "Publish artifacts to Maven Central? non-empty to publish, empty to skip publish"
         required: false
         type: string
-  push:
   schedule:
     - cron: "0 0 * * *"
   pull_request:
+    branches:
+      - '**'
+  push:
+    branches:
+      - main
 
 env:
   ALL_ARCHS: 1


### PR DESCRIPTION
this avoids running CI on pushes to all PR branches which results in a lot of extra / unnecessary burnt CI time on PRs

Noticed by @dae in https://github.com/ankidroid/Anki-Android-Backend/pull/302#issuecomment-1692045781

This is the way we handle it in the main repo, seems to work well