### PR TITLE
ignore 'checkMainThreadOp' unit test error

### DIFF
--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/Backend.kt
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/Backend.kt
@@ -279,6 +279,15 @@ open class Backend(langs: Iterable<String> = listOf("en")) : GeneratedBackend(),
             }
         } catch (exc: NoSuchMethodError) {
             // running outside Android, or old API
+        } catch (ex: RuntimeException) {
+            // If running with no Android dependencies, we get the error:
+            // Method getMainLooper in android.os.Looper not mocked.
+            // See https://developer.android.com/r/studio-ui/build/not-mocked for details.
+            // runIfOnMainThread is non-vital, so we can ignore the exception
+            if (ex.message?.contains("android.os.Looper not mocked") == true) {
+                return
+            }
+            throw ex
         }
     }
 }


### PR DESCRIPTION
Unit tests are much faster if they don't depend on Robolectric, the downside is that we can't depend on Android functionality

Looper.getMainLooper().thread is run only in `checkMainThreadOp` and this is a logging function, so we can ignore the error

```
java.lang.RuntimeException: Method getMainLooper in android.os.Looper not mocked. See https://developer.android.com/r/studio-ui/build/not-mocked for details.
		at android.os.Looper.getMainLooper(Looper.java)
```