### PR TITLE
Workflow actions update (lint, bump versions, use n2, public release new concurrency group)

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -5,7 +5,7 @@ on:
     - cron: "0 0 * * *"
   pull_request:
     branches:
-      - '**'
+      - "**"
   push:
     branches:
       - main

--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -31,23 +31,6 @@ jobs:
       - name: Fetch submodules
         run: git submodule update --init
 
-      - name: Setup Ninja
-        uses: ashutoshvarma/setup-ninja@master
-        with:
-          version: 1.11.1
-
-      # The action puts a relative path on the PATH 🙄
-      - name: Make path absolute
-        if: matrix.os != 'windows-latest'
-        run: echo $(pwd)/ninja_bin >> $GITHUB_PATH
-
-      - name: Make path absolute
-        if: matrix.os == 'windows-latest'
-        run: |
-          $CurrentPath = (Get-Location).Path
-          $NewPath = "${CurrentPath}/ninja_bin"
-          Add-Content -Path $env:GITHUB_PATH -Value $NewPath
-
       - name: Set NDK version
         if: matrix.os != 'windows-latest'
         run: echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
@@ -91,6 +74,16 @@ jobs:
           key: ${{ runner.os }}-rust-debug-v6-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-rust-debug-v6
+
+      - name: Setup N2 (Windows)
+        if: matrix.os == 'windows-latest'
+        # after metge of https://github.com/ankitects/anki/pull/2837
+        # run: ./anki/tools/install-n2.bat
+        run: cargo install --git https://github.com/ankitects/n2.git --rev 3b725cf9c321efb90496dd2458cf5c1abbef4dba
+
+      - name: Setup N2 (Unix)
+        if: matrix.os != 'windows-latest'
+        run: ./anki/tools/install-n2
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 80
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Fetch submodules
         run: git submodule update --init

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: macos-13
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Fetch submodules
         run: git submodule update --init

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,7 +21,7 @@ env:
   CARGO_PROFILE_RELEASE_LTO: fat
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-release
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.mavenPublish }}-release
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,15 +34,6 @@ jobs:
       - name: Fetch submodules
         run: git submodule update --init
 
-      - name: Setup Ninja
-        uses: ashutoshvarma/setup-ninja@master
-        with:
-          version: 1.11.1
-
-      # The action puts a relative path on the PATH 🙄
-      - name: Make path absolute
-        run: echo $(pwd)/ninja_bin >> $GITHUB_PATH
-
       - name: Set NDK version
         run: echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
 
@@ -74,6 +65,9 @@ jobs:
           key: ${{ runner.os }}-rust-release-v6-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-rust-release-v6
+
+      - name: Setup N2
+        run: ./anki/tools/install-n2
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,7 +10,7 @@ on:
     - cron: "0 0 * * *"
   pull_request:
     branches:
-      - '**'
+      - "**"
   push:
     branches:
       - main
@@ -105,7 +105,7 @@ jobs:
       # following steps only run on workflow dispatch
 
       - name: Publish AAR to Maven
-        if: "${{ github.event.inputs.mavenPublish != '' && github.event_name == 'workflow_dispatch'}}"       
+        if: "${{ github.event.inputs.mavenPublish != '' && github.event_name == 'workflow_dispatch'}}"
         env:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
@@ -115,7 +115,7 @@ jobs:
           ./gradlew rsdroid:publishAllPublicationsToMavenCentral -DtestBuildType=release -Dorg.gradle.daemon=false -Dorg.gradle.console=plain
 
       - name: Publish JAR to Maven
-        if: "${{ github.event.inputs.mavenPublish != '' && github.event_name == 'workflow_dispatch'}}"       
+        if: "${{ github.event.inputs.mavenPublish != '' && github.event_name == 'workflow_dispatch'}}"
         env:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}

--- a/.github/workflows/update_gradle_wrapper.yml
+++ b/.github/workflows/update_gradle_wrapper.yml
@@ -13,7 +13,7 @@ jobs:
   update-gradle-wrapper:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 


### PR DESCRIPTION

This was mainly prompted by https://github.com/ankidroid/Anki-Android-Backend/pull/325#issuecomment-1818743536

> I released, but the scheduled CI cancelled the run

Cleaned up a few other things while there

Related https://github.com/ankitects/anki/pull/2837 for a windows n2 install batch script

Learnings:
"concurrency" in github actions is just a string. So whatever string you put in *is* the key used for concurrency lookup when applying concurrency rules if I understand correctly. Thus manipulating it as proposed here should work fine 

https://docs.github.com/en/actions/using-jobs/using-concurrency

> The concurrency key is used to group workflows or jobs together into a concurrency group. When you define a concurrency key, GitHub Actions ensures that only one workflow or job with that key runs at any given time