### PR TITLE
add: BuildConfig & `ANKI_DESKTOP_VERSION`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison-1
-VERSION_NAME=0.1.30-anki23.10.1
+VERSION_NAME=0.1.31-anki23.10.1
 
 POM_INCEPTION_YEAR=2020
 

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -21,6 +21,13 @@ def getAnkiCommitHash = { ->
     return commit
 }
 
+def getAnkiDesktopVersion() {
+    Properties properties = new Properties()
+    properties.load(project.rootProject.file('gradle.properties').newDataInputStream())
+    def versionName = properties.getProperty('VERSION_NAME')
+    return versionName.substring(versionName.indexOf("anki") + "anki".length())
+}
+
 android {
     namespace 'net.ankiweb.rsdroid'
     compileSdk rootProject.ext.compileSdk
@@ -44,6 +51,7 @@ android {
         consumerProguardFiles "consumer-rules.pro"
 
         buildConfigField "String", "ANKI_COMMIT_HASH", "\"${getAnkiCommitHash()}\""
+        buildConfigField "String", "ANKI_DESKTOP_VERSION", "\"${getAnkiDesktopVersion()}\""
     }
 
     buildTypes {

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -26,6 +26,10 @@ android {
     compileSdk rootProject.ext.compileSdk
     ndkVersion "26.1.10909125" // Used by GitHub actions - avoids an install step on some machines
 
+    buildFeatures {
+        buildConfig true // expose 'ANKI_DESKTOP_VERSION'
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
@@ -38,6 +42,8 @@ android {
         versionName VERSION_NAME
 
         consumerProguardFiles "consumer-rules.pro"
+
+        buildConfigField "String", "ANKI_COMMIT_HASH", "\"${getAnkiCommitHash()}\""
     }
 
     buildTypes {


### PR DESCRIPTION
For use in https://github.com/ankidroid/Anki-Android/issues/14909

See: https://github.com/ankidroid/Anki-Android-Backend/commit/c495fd05e0b745e868a27382a1b50c51a0665657 for ANKI_COMMIT_HASH

Also bumps version, expecting a release after this is merged