### PR TITLE
build(ci): upgrade macOS runner to M1 & macOS 14

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-14]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 80
@@ -97,7 +97,7 @@ jobs:
 
       - name: Run tests (Mac)
         uses: reactivecircus/android-emulator-runner@v2
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-14'
         timeout-minutes: 30
         with:
           api-level: 23

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This is a beta, we are currently on `macos-13`. Should lead to performance improvements

https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

> The macos-latest workflow label currently uses the macOS 12 runner image.
> `macos-14` [beta]

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

This reduces the available RAM from 14 to 7GB