### PR TITLE
test(ci): bump actions deps, use new runner capabilities

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -102,6 +102,10 @@ jobs:
         if: contains(matrix.os, 'windows') == false
         run: ./check-rust.sh
 
+      - name: Check Rust (Windows)
+        if: contains(matrix.os, 'windows')
+        run: ./check-rust.bat
+
       - name: Run tests (Emulator)
         uses: reactivecircus/android-emulator-runner@v2
         if: contains(matrix.os, 'ubuntu')

--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -47,13 +47,13 @@ jobs:
         run: Add-Content -Path $env:GITHUB_ENV -Value ANDROID_NDK_HOME=$env:ANDROID_NDK_LATEST_HOME
 
       - name: Configure JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "adopt"
           java-version: "17" # matches Anki-Android
 
       - name: Restore Rust Cache (Windows)
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         if: contains(matrix.os, 'windows')
         with:
           path: |
@@ -68,7 +68,7 @@ jobs:
             ${{ runner.os }}-rust-debug-v7
 
       - name: Restore Rust Cache (Unix)
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         if: contains(matrix.os, 'windows') == false
         with:
           path: |
@@ -86,7 +86,7 @@ jobs:
         run: bash ./anki/tools/install-n2
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         timeout-minutes: 5
         with:
           # Only write to the cache for builds on the 'main' branches, stops branches evicting main cache
@@ -114,21 +114,21 @@ jobs:
           script: ./check-droid.sh
 
       - name: Upload rsdroid AAR as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rsdroid-aar-${{ matrix.os }}
           if-no-files-found: error
           path: rsdroid/build/outputs/aar
 
       - name: Upload rsdroid-robo JAR as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rsdroid-robo-${{ matrix.os }}
           if-no-files-found: error
           path: rsdroid-testing/build/libs
 
       - name: Save Rust Cache (Windows)
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: contains(matrix.os, 'windows') && github.ref == 'refs/heads/main'
         with:
           path: |
@@ -141,7 +141,7 @@ jobs:
           key: ${{ runner.os }}-rust-debug-v7-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
 
       - name: Save Rust Cache (Unix)
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: contains(matrix.os, 'windows') == false && github.ref == 'refs/heads/main'
         with:
           path: |

--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -40,11 +40,15 @@ jobs:
 
       - name: Set NDK version (Unix)
         if: contains(matrix.os, 'windows') == false
-        run: echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
+        run: |
+          echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
+          echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
 
       - name: Set NDK version (Windows)
         if: contains(matrix.os, 'windows')
-        run: Add-Content -Path $env:GITHUB_ENV -Value ANDROID_NDK_HOME=$env:ANDROID_NDK_LATEST_HOME
+        run: |
+          Add-Content -Path $env:GITHUB_ENV -Value ANDROID_NDK_HOME=$env:ANDROID_NDK_LATEST_HOME
+          Add-Content -Path $env:GITHUB_ENV -Value ANDROID_NDK_ROOT=$env:ANDROID_NDK_LATEST_HOME
 
       - name: Configure JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Configure JDK
         uses: actions/setup-java@v4
         with:
-          distribution: "adopt"
-          java-version: "17" # matches Anki-Android
+          distribution: "temurin"
+          java-version: "21" # matches Anki-Android
 
       - name: Restore Rust Cache (Windows)
         uses: actions/cache/restore@v4

--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -31,12 +31,12 @@ jobs:
       - name: Fetch submodules
         run: git submodule update --init
 
-      - name: Set NDK version
-        if: matrix.os != 'windows-latest'
+      - name: Set NDK version (Unix)
+        if: contains(matrix.os, 'windows') == false
         run: echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
 
-      - name: Set NDK version
-        if: matrix.os == 'windows-latest'
+      - name: Set NDK version (Windows)
+        if: contains(matrix.os, 'windows')
         run: Add-Content -Path $env:GITHUB_ENV -Value ANDROID_NDK_HOME=$env:ANDROID_NDK_LATEST_HOME
 
       - name: Configure JDK
@@ -47,7 +47,7 @@ jobs:
 
       - name: Restore Rust Cache (Windows)
         uses: actions/cache/restore@v3
-        if: matrix.os == 'windows-latest'
+        if: contains(matrix.os, 'windows')
         with:
           path: |
             ~/.cargo/registry
@@ -62,7 +62,7 @@ jobs:
 
       - name: Restore Rust Cache (Unix)
         uses: actions/cache/restore@v3
-        if: matrix.os != 'windows-latest'
+        if: contains(matrix.os, 'windows') == false
         with:
           path: |
             ~/.cargo/registry
@@ -91,8 +91,8 @@ jobs:
       - name: Build all (current platform)
         run: cargo run -p build_rust
 
-      - name: Check Rust (Linux)
-        if: matrix.os == 'ubuntu-latest'
+      - name: Check Rust (Unix)
+        if: contains(matrix.os, 'windows') == false
         run: ./check-rust.sh
 
       - name: Run tests (Mac)
@@ -122,7 +122,7 @@ jobs:
 
       - name: Save Rust Cache (Windows)
         uses: actions/cache/save@v3
-        if: matrix.os == 'windows-latest' && github.ref == 'refs/heads/main'
+        if: contains(matrix.os, 'windows') && github.ref == 'refs/heads/main'
         with:
           path: |
             ~/.cargo/registry
@@ -135,7 +135,7 @@ jobs:
 
       - name: Save Rust Cache (Unix)
         uses: actions/cache/save@v3
-        if: matrix.os != 'windows-latest' && github.ref == 'refs/heads/main'
+        if: contains(matrix.os, 'windows') == false && github.ref == 'refs/heads/main'
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -21,12 +21,19 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-14]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 80
     steps:
       - uses: actions/checkout@v4
+
+      - name: Enable KVM group perms (Ubuntu)
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Fetch submodules
         run: git submodule update --init
@@ -95,9 +102,9 @@ jobs:
         if: contains(matrix.os, 'windows') == false
         run: ./check-rust.sh
 
-      - name: Run tests (Mac)
+      - name: Run tests (Emulator)
         uses: reactivecircus/android-emulator-runner@v2
-        if: matrix.os == 'macos-13'
+        if: contains(matrix.os, 'ubuntu')
         timeout-minutes: 30
         with:
           api-level: 23

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Configure JDK
         uses: actions/setup-java@v4
         with:
-          distribution: "adopt"
-          java-version: "17" # matches Anki-Android
+          distribution: "temurin"
+          java-version: "21" # matches Anki-Android
 
       - name: Install Windows cross compiler
         run: brew install mingw-w64 && x86_64-w64-mingw32-gcc -v

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -35,7 +35,9 @@ jobs:
         run: git submodule update --init
 
       - name: Set NDK version
-        run: echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
+        run: |
+          echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
+          echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
 
       - name: Configure JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -38,7 +38,7 @@ jobs:
         run: echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
 
       - name: Configure JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "adopt"
           java-version: "17" # matches Anki-Android
@@ -53,7 +53,7 @@ jobs:
           x86_64-unknown-linux-gnu-gcc -v
 
       - name: Restore Rust Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/registry
@@ -70,7 +70,7 @@ jobs:
         run: ./anki/tools/install-n2
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         timeout-minutes: 5
         with:
           # Only write to the cache for builds on the 'main' branches, stops branches evicting main cache
@@ -83,14 +83,14 @@ jobs:
         run: ./build.sh
 
       - name: Upload rsdroid AAR as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rsdroid-aar
           if-no-files-found: error
           path: rsdroid/build/outputs/aar
 
       - name: Upload rsdroid-robo JAR as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rsdroid-robo
           if-no-files-found: error
@@ -125,7 +125,7 @@ jobs:
           ./gradlew rsdroid-testing:publishAllPublicationsToMavenCentral -Dorg.gradle.project.macCC=$ANKIDROID_MACOS_CC -DtestBuildType=debug -Dorg.gradle.daemon=false -Dorg.gradle.console=plain
 
       - name: Save Rust Cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: github.ref == 'refs/heads/main'
         with:
           path: |

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ tasks.register('clean', Delete) {
 
 ext {
     jvmVersion = Jvm.current().javaVersion.majorVersion
-    if (jvmVersion != "17" && jvmVersion != 21) {
+    if (jvmVersion != "17" && jvmVersion != "21") {
         println "\n\n\n"
         println "**************************************************************************************************************"
         println "\n\n\n"

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison-1
-VERSION_NAME=0.1.34-anki23.12.1
+VERSION_NAME=0.1.35-anki23.12.1
 
 POM_INCEPTION_YEAR=2020
 


### PR DESCRIPTION
Here's a big batch of workflow improvements, ~~and a minSdk bump~~:

- run all the mac stuff on the new / faster macos-14 runners
- switch emulator test to ubuntu (which has nested virt now) since macos-14 can't run that. It's fast anyway
- bump all the workflow action versions
- use a slightly more stable matrix runner check style (contains, no OS version needed)
- ~~bump minSdk to 23 to match AnkiDroid~~
- use JDK21 in CI now that it is stable

because of all the changes, I want to do a test release of this to make sure the release process works, so I bumped the backend version

After merge I'll try the full release from main