### PR TITLE
build(ci): fix ubuntu runner storage issue with pre-clean

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -26,6 +26,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 80
     steps:
+      - name: Liberate disk space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        if: contains(matrix.os, 'ubuntu')
+        with:
+          tool-cache: false
+          android: false
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - name: Enable KVM group perms (Ubuntu)


### PR DESCRIPTION
Adopt an action that helpfully removes large pre-installed things from the runner which our workflows do not need

See https://github.com/actions/runner-images/issues/7969