### PR TITLE
Add option for a custom root certificate

### DIFF
--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/Backend.kt
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/Backend.kt
@@ -34,7 +34,7 @@ import timber.log.Timber
 import java.io.Closeable
 import java.io.File
 
-open class Backend(langs: Iterable<String> = listOf("en")) : GeneratedBackend(), SQLHandler, Closeable {
+open class Backend(langs: Iterable<String> = listOf("en"), custom_cert: String = "") : GeneratedBackend(), SQLHandler, Closeable {
     // Set on init; unset on .close(). Access via withBackend()
     private var backendPointer: Long? = null
 
@@ -72,8 +72,13 @@ open class Backend(langs: Iterable<String> = listOf("en")) : GeneratedBackend(),
     init {
         checkMainThreadOp()
         Timber.d("Opening rust backend with lang=$langs")
+
+        if (custom_cert != "")
+            Timber.d("Also using a custom certificate with the backend")
+
         val input = BackendInit.newBuilder()
                 .addAllPreferredLangs(langs)
+                .setCustomCert(custom_cert)
                 .build()
                 .toByteArray()
         val outBytes = unpackResult(NativeMethods.openBackend(input))

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendFactory.kt
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendFactory.kt
@@ -29,6 +29,12 @@ object BackendFactory {
      */
     var defaultLanguages: Iterable<String> = listOf("en")
 
+    /**
+     * Custom root certificate used in the Rust backend (PEM format)
+     */
+    @JvmStatic
+    private var custom_cert: String? = null
+
     @JvmStatic
     private var backendForTesting: CustomBackendCreator? = null
 
@@ -36,9 +42,28 @@ object BackendFactory {
     @JvmOverloads
     fun getBackend(languages: Iterable<String>? = null): Backend {
         val langs = languages ?: defaultLanguages
+        val custom_cert = this.custom_cert ?: ""
+
         return backendForTesting?.invoke(langs) ?: Backend(
                 langs,
+                custom_cert,
         )
+    }
+
+    /**
+     * Set the custom root certificate for use in the backend.
+     * Backend needs to reloaded after this operation.
+     */
+    @JvmStatic
+    fun setCustomCert(custom_cert: String?)
+    {
+        this.custom_cert = custom_cert
+    }
+
+    /** Get the current custom root certificate used in the backend */
+    @JvmStatic
+    fun getCustomCert(): String? {
+        return this.custom_cert
     }
 
     /** Allows overriding the returned backend for unit tests */


### PR DESCRIPTION
Let Ankidroid set a custom root certificate to use in the Rust backend. Requires https://github.com/ankitects/anki/pull/3095