### PR TITLE
build(ci): publish to Maven Central Portal under `io.github.david-allison`

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -105,8 +105,8 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
-          ORG_GRADLE_PROJECT_mavenCentralUsername: david-allison-1
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         run: |
           ./gradlew rsdroid:publishAllPublicationsToMavenCentral -DtestBuildType=release -Dorg.gradle.daemon=false -Dorg.gradle.console=plain
 
@@ -115,8 +115,8 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
-          ORG_GRADLE_PROJECT_mavenCentralUsername: david-allison-1
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         run: |
           export ANKIDROID_LINUX_CC=x86_64-unknown-linux-gnu-gcc
           export ANKIDROID_MACOS_CC=cc

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ the repository.
 1. Head over to the main `Anki-Android` repository and update the
 `AnkiDroid/build.gradle` file there to adopt the new backend version once it
 shows up in
-https://repo1.maven.org/maven2/io/github/david-allison-1/anki-android-backend/
+https://repo1.maven.org/maven2/io/github/david-allison/anki-android-backend/
 
 ## Architecture
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.26.0'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.28.0'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=false
 
-GROUP=io.github.david-allison-1
+GROUP=io.github.david-allison
 VERSION_NAME=0.1.35-anki23.12.1
 
 POM_INCEPTION_YEAR=2020

--- a/rsdroid-testing/build.gradle
+++ b/rsdroid-testing/build.gradle
@@ -1,3 +1,5 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 import java.util.jar.JarFile
 
 /*
@@ -52,7 +54,7 @@ java.sourceCompatibility JavaVersion.VERSION_11
 java.targetCompatibility JavaVersion.VERSION_11
 
 mavenPublishing {
-    publishToMavenCentral("DEFAULT", true)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
     // publishToMavenCentral("S01") for publishing through s01.oss.sonatype.org
     signAllPublications()
 }

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -1,4 +1,5 @@
 import com.android.build.gradle.tasks.BundleAar
+import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.zip.ZipFile
 
@@ -128,7 +129,9 @@ tasks.withType(KotlinCompile).configureEach {
 }
 
 mavenPublishing {
-    publishToMavenCentral("DEFAULT", true)
+    // Use https://central.sonatype.com/account with david-allison's GitHub login, not Google
+    // the host should match rsdroid-testing
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
     // publishToMavenCentral("S01") for publishing through s01.oss.sonatype.org
     signAllPublications()
 }


### PR DESCRIPTION
## Summary

We could no longer publish to Maven Central's legacy NXRM (also called OSSRH) under `io.github.david-allison-1` [see: **Cause**]

This fix moves to publish on https://central.sonatype.com/ under `groupId` `io.github.david-allison`

## Fixes 
* Fixes #347
* Closes https://github.com/ankidroid/Anki-Android-Backend/pull/360

## Useful
Use david-allison's GitHub login for https://central.sonatype.com/account, not Google

## Approach

### 1. Define the following in CI:

> [!NOTE]
> Step 1 is done outside this PR

* `MAVEN_CENTRAL_USERNAME`
* `MAVEN_CENTRAL_PASSWORD`

Obtained from https://central.sonatype.com/account WARNING: use GitHub login for david-allison, not Google

`MAVEN_CENTRAL_USERNAME` looks randomly generated, I don't know if it's secure to share as the username/password pair are defined as a User Token, so I stored it as a secret

### 2. Update `gradle-maven-publish-plugin` to publish to `CENTRAL_PORTAL`
  * This required a `gradle-maven-publish-plugin` update

Revert "fix: attempt maven publish plugin revert to last working version"

This reverts commit c765d96e7828415b50600bb6d5c41ec058071c88.

----

### 3. Update GitHub Actions

* `ORG_GRADLE_PROJECT_mavenCentralUsername`
* `ORG_GRADLE_PROJECT_mavenCentralPassword`

Use the variables defined in 1)

### 4. Update groupId to `io.github.david-allison`

I have control over this `groupId` on Maven Central Portal

## Cause

Either/or:

* Our build plugin was updated
* Maven revoked our access to `io.github.david-allison-1` due to a security issue
  * https://blog.oversecured.com/Introducing-MavenGate-a-supply-chain-attack-method-for-Java-and-Android-applications/
  * due to my account rename from `david-allison-1` -> `david-allison`

We **could** submit a signed artefact proving ownership of `david-allison-1` but since our private key was in CI, and this namespace is now published as insecure it was decided it would be better to move to `io.github.david-allison`

Note: This is due to potential complications with setting up DNS on ankidroid.org `org.ankidroid` would be better