### PR TITLE
build(ci): remove log: 'Publishing to Sonatype will not work'

### DIFF
--- a/rsdroid-testing/build.gradle
+++ b/rsdroid-testing/build.gradle
@@ -59,20 +59,6 @@ mavenPublishing {
     signAllPublications()
 }
 
-signing {
-    def hasPrivate = project.hasProperty('SIGNING_PRIVATE_KEY')
-    def hasPassword = project.hasProperty('SIGNING_PASSWORD')
-    if (hasPrivate && hasPassword) {
-        useInMemoryPgpKeys(project.getProperty('SIGNING_PRIVATE_KEY'), project.getProperty('SIGNING_PASSWORD'))
-    } else {
-        def message = "Publishing to Sonatype will not work - PGP keys not set for publishing"
-
-        def pk = System.getenv("ORG_GRADLE_PROJECT_SIGNING_PRIVATE_KEY")
-        def pwd = System.getenv("ORG_GRADLE_PROJECT_SIGNING_PASSWORD")
-
-        logger.warn("$message: ${hasPrivate}, ${hasPassword}, ${pk == null || "" == pk}, ${pwd == null || "" == pwd}")
-    }
-}
 buildscript {
     repositories {
         mavenCentral()

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -135,18 +135,3 @@ mavenPublishing {
     // publishToMavenCentral("S01") for publishing through s01.oss.sonatype.org
     signAllPublications()
 }
-
-signing {
-    def hasPrivate = project.hasProperty('SIGNING_PRIVATE_KEY')
-    def hasPassword = project.hasProperty('SIGNING_PASSWORD')
-    if (hasPrivate && hasPassword) {
-        useInMemoryPgpKeys(project.getProperty('SIGNING_PRIVATE_KEY'), project.getProperty('SIGNING_PASSWORD'))
-    } else {
-        def message = "Publishing to Sonatype will not work - PGP keys not set for publishing"
-
-        def pk = System.getenv("ORG_GRADLE_PROJECT_SIGNING_PRIVATE_KEY")
-        def pwd = System.getenv("ORG_GRADLE_PROJECT_SIGNING_PASSWORD")
-
-        logger.warn("$message: ${hasPrivate}, ${hasPassword}, ${pk == null || "" == pk}, ${pwd == null || "" == pwd}")
-    }
-}


### PR DESCRIPTION
No longer relevant: `signAllPublications` calls `useInMemoryPgpKeys`

`signAllPublications` added in f1ceb21b94d8745e107779f8e3b3c723805c2def

* Fixes #362

Untested, but we hit the 'false' branch and publishing still worked