### PR TITLE
Remap POST requests url

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison
-VERSION_NAME=0.1.36-anki24.04
+VERSION_NAME=0.1.37-anki24.04
 
 POM_INCEPTION_YEAR=2020
 


### PR DESCRIPTION
Summary of the issue: 

Loading files with `file:/` scheme in much faster in an Android Webview, and that's what 2.15.6 did by setting the Webview base url to the media directory. 

But in 2.16/2.17, in order to enable POST requests to be done, the base url was set to localhost and the files were delivered by the server. After noticing that loading files was slower with the server, a `WebViewAssetLoader` was used, but it was still slower than `file:/`. The next alternative was parsing the card's HTML to use `file:/` for media sources, but that leads to CORS issues and sometimes HTML parsing issues.

So, here's what I believe that should be the definitive solution, which is to remap POST requests base url, so the Webview base url can be set to the media directory so the 2.15.6 behavior is restored.

---

Basically, this replaces `"/_anki/"` in `reviewer.js` and `reviewer_extras_bundle.js` so a custom post base url can be used if set in AnkiDroid.

My experience with Rust is almost zero, so I expect that there should be better practices than what I did.

Tested with [this PR](https://github.com/ankidroid/Anki-Android/pull/16140) by adding `console.log("foo");` into `Custom scheduling` deck option.

---

Ideally, this should be unit tested, but **I currently don't have time for that, nor for dealing with requested changes in this PR, so please take over this if time is of the essence.**
