### PR TITLE
fix: retry rust build on ubuntu

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -112,7 +112,15 @@ jobs:
           gradle-home-cache-cleanup: true
 
       - name: Build all (current platform)
-        run: cargo run -p build_rust
+        # Ubuntu currently requires multiple build attempts before it succeeds - it builds a little further each time then works
+        # This happens the same way every time in CI so far, and is reproducible locally if you have an Ubuntu system
+        # This needs a root-cause analysis (see #373) but we will use a retry hack for Ubuntu only to unblock PRs until that is done
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: ${{ contains(matrix.os, 'ubuntu') == true && 5 || 1 }}
+          retry_on: error
+          command: cargo run -p build_rust
 
       - name: Check Rust (Unix)
         if: contains(matrix.os, 'windows') == false


### PR DESCRIPTION
it appears to converge over multiple runs to a working build

this is based on a report of convergent build behavior by Brayan, we'll see how it goes

Fixes:
- Fixes #373 