### PR TITLE
feat: optionally log calls on main thread

### DIFF
--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/Backend.kt
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/Backend.kt
@@ -196,6 +196,7 @@ open class Backend(langs: Iterable<String> = listOf("en")) : GeneratedBackend(),
     }
 
     private fun checkMainThreadOp(sql: String? = null) {
+        if (!checkOperationsRunOnMainThread) return
         runIfOnMainThread {
             val stackTraceElements = Thread.currentThread().stackTrace
             val firstElem = stackTraceElements.filter {
@@ -237,6 +238,15 @@ open class Backend(langs: Iterable<String> = listOf("en")) : GeneratedBackend(),
             }
             throw ex
         }
+    }
+
+    companion object {
+        /**
+         * Debug setting: if true, logs all operations executed on the main thread
+         */
+        // This is false by default: translate() ais an extremely fast operation
+        // which does not require execution on a worker thread
+        var checkOperationsRunOnMainThread: Boolean = false
     }
 }
 


### PR DESCRIPTION
Also changes default to 'off'

Previously it was required

* The logging is a slow operation
* translate() does not require it
* `browserRowForId()` probably does not require it
* This spams logs in production

We've made great progress tackling `getColUnsafe`, and just by the name, we will eventually get to 0
usages

The logging is less relevant now, especially as
AnkiDroid: 043ded78761fea83a0614206eb987eb891799b9d means that it's compiler warning
to access the collection with the main thread

Fixes 385