### PR TITLE
Update NDK to v27, Anki to 24.06.3

### DIFF
--- a/.github/scripts/install_ndk.bat
+++ b/.github/scripts/install_ndk.bat
@@ -1,0 +1,12 @@
+@echo off
+if [%1]==[] goto usage
+
+echo Installing NDK %1
+echo %PATH%
+sdkmanager --list_installed | findstr ndk
+sdkmanager --install "ndk;%1" --sdk_root=%ANDROID_SDK_ROOT% | findstr /v =
+sdkmanager --list_installed | findstr ndk
+exit /b 0
+
+:usage
+echo Usage: %0 NDK Version (ex 21.3.6528147)

--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   DEBUG: 1
+  ANDROID_NDK_VERSION: "27.0.12077973"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -50,15 +51,21 @@ jobs:
       - name: Fetch submodules
         run: git submodule update --init
 
-      - name: Set NDK version (Unix)
-        if: contains(matrix.os, 'windows') == false
+      - name: Install/Set NDK version (Unix)
+        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
         run: |
+          export PATH="$PATH:$ANDROID_HOME/cmdline-tools/latest/bin"
+          ./.github/scripts/install_ndk.sh ${ANDROID_NDK_VERSION}
+          export ANDROID_NDK_LATEST_HOME="${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}"
           echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
           echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
 
-      - name: Set NDK version (Windows)
+      - name: Install/Set NDK version (Windows)
         if: contains(matrix.os, 'windows')
         run: |
+          $env:PATH = "$env:PATH;$env:ANDROID_HOME\cmdline-tools\latest\bin"
+          ./.github/scripts/install_ndk.bat $env:ANDROID_NDK_VERSION
+          $env:ANDROID_NDK_LATEST_HOME = "$env:ANDROID_SDK_ROOT\ndk\$env:ANDROID_NDK_VERSION"
           Add-Content -Path $env:GITHUB_ENV -Value ANDROID_NDK_HOME=$env:ANDROID_NDK_LATEST_HOME
           Add-Content -Path $env:GITHUB_ENV -Value ANDROID_NDK_ROOT=$env:ANDROID_NDK_LATEST_HOME
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,6 +19,7 @@ env:
   ALL_ARCHS: 1
   RELEASE: 1
   CARGO_PROFILE_RELEASE_LTO: fat
+  ANDROID_NDK_VERSION: "27.0.12077973"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.mavenPublish }}-release
@@ -34,8 +35,11 @@ jobs:
       - name: Fetch submodules
         run: git submodule update --init
 
-      - name: Set NDK version
+      - name: Install/Set NDK version
         run: |
+          export PATH="$PATH:$ANDROID_HOME/cmdline-tools/latest/bin"
+          ./.github/scripts/install_ndk.sh ${ANDROID_NDK_VERSION}
+          export ANDROID_NDK_LATEST_HOME="${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}"
           echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
           echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
 

--- a/.github/workflows/update_gradle_wrapper.yml
+++ b/.github/workflows/update_gradle_wrapper.yml
@@ -29,7 +29,7 @@ jobs:
     # COULD_BE_BETTER: Consider turning this into a GitHub action - help the wider community
     # NDK install (unzipping) is really noisy - silence the log spam with grep, while keeping errors
     - name: Install NDK (silent)
-      run: .github/scripts/install_ndk.sh 26.1.10909125
+      run: .github/scripts/install_ndk.sh 27.0.12077973
 
     - name: Update Gradle Wrapper
       uses: gradle-update/update-gradle-wrapper-action@v1

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ On Windows:
 In Android Studio, choose the Tools>SDK Manager menu option.
 
 - In SDK tools, enable "show package details"
-- Choose NDK version 26.1.10909125.
+- Choose NDK version 27.0.12077973
 - After downloading, you may need to restart Android Studio to get it to
 synchronize gradle.
 
@@ -82,19 +82,19 @@ eg on Linux:
 
 ```
 export ANDROID_SDK_ROOT=$HOME/Android/Sdk
-export ANDROID_NDK_HOME=$HOME/Android/Sdk/ndk/26.1.10909125
+export ANDROID_NDK_HOME=$HOME/Android/Sdk/ndk/27.0.12077973
 ```
 
 Or macOS:
 
 ```
 export ANDROID_SDK_ROOT=$HOME/Library/Android/sdk
-export ANDROID_NDK_HOME=$HOME/Library/Android/sdk/ndk/26.1.10909125
+export ANDROID_NDK_HOME=$HOME/Library/Android/sdk/ndk/27.0.12077973
 ```
 Or Windows using Powershell:
 
 ```
-$env:ANDROID_NDK_HOME="$env:ANDROID_SDK_ROOT\ndk\26.1.10909125"
+$env:ANDROID_NDK_HOME="$env:ANDROID_SDK_ROOT\ndk\27.0.12077973"
 ```
 If you don't have Java installed, you may be able to use the version bundled
 with Android Studio. Eg on macOS:

--- a/build-rust.gradle
+++ b/build-rust.gradle
@@ -2,7 +2,7 @@ tasks.register('buildRust', Exec) {
     // ensure script doesn't try to start gradle again
     environment 'RUNNING_FROM_GRADLE', '1'
     if (!System.getenv('ANDROID_NDK_HOME')) {
-        String ndkPath = "${getSdkDir()}/ndk/26.1.10909125"
+        String ndkPath = "${getSdkDir()}/ndk/27.0.12077973"
         environment 'ANDROID_NDK_HOME', ndkPath
     }
     workingDir "$rootDir"

--- a/build_rust/src/main.rs
+++ b/build_rust/src/main.rs
@@ -17,8 +17,8 @@ fn main() -> Result<()> {
         return Ok(());
     }
     let ndk_path = Utf8PathBuf::from(env::var("ANDROID_NDK_HOME").unwrap_or_default());
-    if !ndk_path.file_name().unwrap_or_default().starts_with("26.") {
-        panic!("Expected ANDROID_NDK_HOME to point to a 26.x NDK. Future versions may work, but are untested.");
+    if !ndk_path.file_name().unwrap_or_default().starts_with("27.") {
+        panic!("Expected ANDROID_NDK_HOME to point to a 27.x NDK. Future versions may work, but are untested.");
     }
 
     build_web_artifacts()?;
@@ -125,7 +125,7 @@ fn build_android_jni() -> Result<()> {
     let ndk_targets = add_android_rust_targets(all_archs)?;
     let (is_release, _release_dir) = check_release(false);
 
-    Command::run("cargo install cargo-ndk@3.3.0")?;
+    Command::run("cargo install cargo-ndk@3.5.4")?;
 
     let mut command = Command::new("cargo");
     command
@@ -141,6 +141,7 @@ fn build_android_jni() -> Result<()> {
     if is_release {
         command.arg("--release");
     }
+    command.env("RUSTFLAGS", "-C link-args=-Wl,-z,max-page-size=16384");
     command.ensure_success()?;
 
     Ok(())

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison
-VERSION_NAME=0.1.39-anki24.06.2
+VERSION_NAME=0.1.40-anki24.06.3
 
 POM_INCEPTION_YEAR=2020
 

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -40,7 +40,7 @@ static def getBackendGitCommitHash() {
 android {
     namespace 'net.ankiweb.rsdroid'
     compileSdk rootProject.ext.compileSdk
-    ndkVersion "26.1.10909125" // Used by GitHub actions - avoids an install step on some machines
+    ndkVersion "27.0.12077973" // Used by GitHub actions - avoids an install step on some machines
 
     buildFeatures {
         buildConfig true // expose 'ANKI_DESKTOP_VERSION'

--- a/rslib-bridge/build.rs
+++ b/rslib-bridge/build.rs
@@ -33,7 +33,7 @@ fn main() -> Result<()> {
         } else {
             "windows-x86_64"
         };
-        let lib_dir = format!("/toolchains/llvm/prebuilt/{platform}/lib/clang/17/lib/linux/");
+        let lib_dir = format!("/toolchains/llvm/prebuilt/{platform}/lib/clang/18/lib/linux/");
         println!("cargo:rustc-link-search={android_ndk_home}/{lib_dir}");
         println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");
     }

--- a/tools/doctor.sh
+++ b/tools/doctor.sh
@@ -2,7 +2,7 @@
 
 set -e # Error out if there were any problems
 
-ANDROID_NDK_VERSION="26.1.10909125"
+ANDROID_NDK_VERSION="27.0.12077973"
 
 red=31
 green=32


### PR DESCRIPTION
So there's also this thing about 16 kb page sizes (https://developer.android.com/guide/practices/page-sizes). I have confirmed that I get librsdroid with a 16kb page size, so that should now be fine on the Anki-Android-Backend side:
![image](https://github.com/user-attachments/assets/0ffd8e63-2a17-4d42-9106-5a0759563839)
But I haven't really managed to get an emulator running with a 16kb page size. The one provided by Google seems to still be reporting a 4kb page size for the system, same as the regular Android 15 image? Basically, right now we can't really confirm that it runs as it should in Anki-Android under Android 15 with a 16kb page size (because no such image actually exists). But it does run as it should otherwise.

Regarding the NDK download scripts... These, along with the workflows for building a release, were refactored because the macOS image has an out-of-date NDK for now (26 instead of latest 27). So I basically made sure that in the future, in case Windows/Ubuntu gets an outdated NDK, we can just download the one version we want anyway. I would like to find a way to refactor the NDK versions in the codebase so it's no longer hardcoded. But maybe we'll leave that for another time?

Should fix:
* Fixes https://github.com/ankidroid/Anki-Android-Backend/issues/399
* Fixes https://github.com/ankidroid/Anki-Android-Backend/issues/398