### PR TITLE
Update Rust to 1.81 following CVE

### DIFF
--- a/.github/scripts/purge_ndk.sh
+++ b/.github/scripts/purge_ndk.sh
@@ -1,0 +1,18 @@
+: ${1?"Usage: $0 NDK Version (ex 21.3.6528147)"}
+
+echo "purging unused NDKs, keeping NDK $1..."
+
+# (i know, i know)
+brew install grep
+
+list=$(sdkmanager --list_installed | ggrep -Eo "ndk;[0-9.]+")
+for ver in $list
+do
+    if [ ! "ndk;$1" == "$ver" ];
+    then
+        echo "uninstalling ndk version $ver"
+        sdkmanager --uninstall $ver
+    fi
+done
+
+echo "done purging old NDKs!"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           export PATH="$PATH:$ANDROID_HOME/cmdline-tools/latest/bin"
           ./.github/scripts/install_ndk.sh ${ANDROID_NDK_VERSION}
+          ./.github/scripts/purge_ndk.sh ${ANDROID_NDK_VERSION}
           export ANDROID_NDK_LATEST_HOME="${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}"
           echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
           echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -68,9 +68,9 @@ jobs:
             anki/out/rust
             anki/out/extracted
             anki/out/node_modules
-          key: ${{ runner.os }}-rust-release-v6-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
+          key: ${{ runner.os }}-rust-release-v7-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-rust-release-v6
+            ${{ runner.os }}-rust-release-v7
 
       - name: Setup N2
         run: ./anki/tools/install-n2
@@ -141,4 +141,4 @@ jobs:
             anki/out/rust
             anki/out/download
             anki/out/node_modules
-          key: ${{ runner.os }}-rust-release-v6-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
+          key: ${{ runner.os }}-rust-release-v7-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,6 +2716,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-format"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4272,12 +4278,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -4292,10 +4299,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # older versions may fail to compile; newer versions may fail the clippy tests
-channel = "1.75"
+channel = "1.81.0"


### PR DESCRIPTION
See: https://vuldb.com/?id.276509
Backend affected by this because of `std::process::Command` usage, and a rustc version <1.81.0.
The `time` cargo dependency had to be updated following this change, otherwise you would get this error:
```
error[E0282]: type annotations needed for `Box<_>`
...
= note: this is an inference error on crate `time` caused by an API change in Rust 1.80.0; update `time` to version `>=0.3.35` by calling `cargo update`
```