### PR TITLE
build(ci): deflake steps with network fetches via retry

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -122,10 +122,11 @@ jobs:
         # Ubuntu currently requires multiple build attempts before it succeeds - it builds a little further each time then works
         # This happens the same way every time in CI so far, and is reproducible locally if you have an Ubuntu system
         # This needs a root-cause analysis (see #373) but we will use a retry hack for Ubuntu only to unblock PRs until that is done
+        # For non-Ubuntu systems, we use retries as the build fetches network resources and those may flake
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 30
-          max_attempts: ${{ contains(matrix.os, 'ubuntu') == true && 5 || 1 }}
+          max_attempts: ${{ contains(matrix.os, 'ubuntu') == true && 5 || 3 }}
           retry_wait_seconds: 0
           retry_on: error
           command: cargo run -p build_rust

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -87,7 +87,14 @@ jobs:
           gradle-home-cache-cleanup: true
 
       - name: Build all
-        run: ./build.sh
+        # We use retries as the build fetches network resources and those may flake
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_wait_seconds: 0
+          retry_on: error
+          command: cargo run -p build_rust
 
       - name: Upload rsdroid AAR as artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION

Took a flake failure in CI last night and it so happens that the rust build also builds node things and that does network fetches

These are known flakes in CI, and handled well with a retry style, so wrapping the rust build in retries on all platforms in quick build now, and also in the build on release

Fail: 

```

rslib:i18n
failed: download:node
Error: error decoding response body

Caused by:
    0: error reading a body from connection
    1: end of file before message length reached
```

https://github.com/ankidroid/Anki-Android-Backend/actions/runs/11265493032/job/31327402861#step:13:459