### PR TITLE
test(ci): pin ubuntu workflows to ubuntu-22.04 temporarily

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-14]
+        os: [ubuntu-22.04, windows-latest, macos-14]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 80

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-22.04' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       # required for all workflows


### PR DESCRIPTION
until we handle ubuntu-24 well, we need CI unblocked

If CI goes green, this is good to go

Related: #422 - most issues fixed there but still something wrong and I don't want it to be critical path when the pin workaround is easy