### PR TITLE
test(ci): use gradle directly vs deprecated gradle-build-action

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -140,9 +140,7 @@ jobs:
         run: ./check-rust.bat
 
       - name: Run tests (Unit)
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: test rsdroid:lint --daemon
+        run: ./gradlew test rsdroid:lint --daemon
 
       - name: Run tests (Emulator)
         uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
we have already converted to setup-gradle, which means that direct gradle usage should now be fully configured, and using gradle directly is the recommended style after using setup-gradle

success criteria is that the unit tests on all three build quick platforms run successfully, and that there are no longer deprecation warnings on the build-quick job summar