### PR TITLE
Add FSRS version to BuildConfig

### DIFF
--- a/build_rust/src/main.rs
+++ b/build_rust/src/main.rs
@@ -143,6 +143,7 @@ fn build_android_jni() -> Result<()> {
     let (is_release, _release_dir) = check_release(false);
 
     Command::run("cargo install cargo-ndk@3.5.4")?;
+    Command::run("cargo install jaq@1.6.0")?;
 
     let mut command = Command::new("cargo");
     command

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -26,7 +26,7 @@ def getAnkiCommitHash = { ->
 def getFsrsVersion = { ->
     def pkgStdout = new ByteArrayOutputStream()
     exec {
-        commandLine "cargo", "metadata", "--format-version=1", "--manifest-path=" + new File("${project.rootDir}", "anki/Cargo.toml")
+        commandLine "cargo", "metadata", "--locked", "--format-version=1", "--manifest-path=" + new File("${project.rootDir}", "anki/Cargo.toml")
         standardOutput = pkgStdout
     }
 

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -2,6 +2,7 @@ import com.android.build.gradle.tasks.BundleAar
 import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.zip.ZipFile
+import org.gradle.internal.os.OperatingSystem
 
 apply plugin: 'com.android.library' // required for aar generation to link to from AnkiDroid
 apply plugin: "kotlin-android"
@@ -20,6 +21,31 @@ def getAnkiCommitHash = { ->
     def commit = hashStdOut.toString().trim()
     println("Anki commit: ${commit}")
     return commit
+}
+
+def getFsrsVersion = { ->
+    def pkgStdout = new ByteArrayOutputStream()
+    exec {
+        commandLine "cargo", "metadata", "--format-version=1", "--manifest-path=" + new File("${project.rootDir}", "anki/Cargo.toml")
+        standardOutput = pkgStdout
+    }
+
+    def verArgs = OperatingSystem.current() == OperatingSystem.WINDOWS ?
+    ".packages[] | select(.name==\\\"fsrs\\\") | .version" :
+    ".packages[] | select(.name==\"fsrs\") | .version"
+    def verStdout = new ByteArrayOutputStream()
+    def verStdin = new ByteArrayInputStream(pkgStdout.toByteArray())
+    exec {
+        // use "jaq" cargo module installed during rust build: self-contained + cross-platform
+        // if we use `jq` we are dependent on local system utility installation status
+        commandLine "jaq", verArgs
+        standardInput = verStdin
+        standardOutput = verStdout
+    }
+
+    def version = verStdout.toString().trim().replace("\"", "")
+    println("FSRS version: ${version}")
+    return version
 }
 
 def getAnkiDesktopVersion() {
@@ -61,6 +87,7 @@ android {
 
         buildConfigField "String", "ANKI_COMMIT_HASH", "\"${getAnkiCommitHash()}\""
         buildConfigField "String", "ANKI_DESKTOP_VERSION", "\"${getAnkiDesktopVersion()}\""
+        buildConfigField "String", "FSRS_VERSION", "\"${getFsrsVersion()}\""
 
         buildConfigField "String", "BACKEND_GIT_COMMIT_HASH", "\"${getBackendGitCommitHash()}\""
         buildConfigField "long", "BACKEND_BUILD_TIME", System.currentTimeMillis().toString()


### PR DESCRIPTION
Excerpt from the Discord (slightly edited):
"i just used the FSRS crate version. actually pulling the version from the JS file (in the "normal" format, i.e. "FSRS 5.x.x") would require us to checkout the fsrs4anki repo with the branch==fsrs crate version, then pull the version from the js file with some regex.. very messy.
using the fsrs crate version would be that we can track any change to the FSRS crate, not just to the algorithm.
pulling the hash of the fsrs git commit can also be done, but is messy because anki is fed the fsrs dep through crates.io and not through github. so, best avoided. 
![image](https://github.com/user-attachments/assets/815ce0d9-f50e-4db9-a440-3b93c0db44ee)"

Related issue: https://github.com/ankidroid/Anki-Android/issues/17236