### PR TITLE
build(deps): result of `cargo check`, the FSRS update from anki 24.10beta3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bbd56ab9e6c5d40802c7f73701b9cc4bccf9fa29037799a94ac9f1a94f1a5f7"
+checksum = "2434366942bf285f3c0691e68d731e56f4e1fc1d8ec7b6a0e9411e94eda6ffbd"
 dependencies = [
  "burn",
  "itertools 0.12.1",

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ commands below are supposed to be executed in the current repo.
 
 ### Download Anki submodule
 
-    git submodule update --init
+    git submodule update --init --recursive
 
 ### C toolchain
 
@@ -151,6 +151,7 @@ latest stable release. You can find the latest tag by running `git tag|sort
 1. run `cd anki` to change into the anki submodule directory,
 1. run `git fetch $SOME_REPO` to ensure you obtain the latest change from this repo.
 1. run `git checkout $COMMIT_IDENTIFIER --recurse-submodules` to obtain the version of the code at this particular commit.
+1. move back to the root of the repo (not the submodule) and run `cargo check` to update our Cargo.lock with any updated versions from the submodule
 
 ### Creating and Publishing a release
 


### PR DESCRIPTION

this should have been done and committed when updating the anki submodule sha

updated the documentation around bumping the anki sha as a note to my future self so that I will hopefully remember this step

Noticed this as I was reviewing #427 - because it had a lockfile FSRS bump in there when it really should not have, but the bump it had was important and should have already been done

Peeling it off here so that #427 is cherry-pickable to stable release-2.19 branch