### PR TITLE
feat: adopt upstream 24.10rc1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
  "sha1",
  "snafu",
  "strum 0.26.3",
- "syn 2.0.79",
+ "syn 2.0.82",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -181,7 +181,6 @@ dependencies = [
  "unic-ucd-category",
  "unicase",
  "unicode-normalization",
- "utime",
  "windows 0.56.0",
  "zip",
  "zstd 0.13.2",
@@ -258,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
 name = "arrayref"
@@ -285,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.13"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e614738943d3f68c628ae3dbce7c3daffb196665f82f8c8ea6b65de73c79429"
+checksum = "0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857"
 dependencies = [
  "futures-core",
  "memchr",
@@ -305,7 +304,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -413,7 +412,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -670,7 +669,7 @@ dependencies = [
  "derive-new",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -809,7 +808,7 @@ checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1175,7 +1174,7 @@ checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1224,7 +1223,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1261,7 +1260,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1455,7 +1454,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1485,15 +1484,16 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "1.3.1"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2434366942bf285f3c0691e68d731e56f4e1fc1d8ec7b6a0e9411e94eda6ffbd"
+checksum = "42155527199b3e7b6ad47e9db849ee25bd5bd436ee17a72ae0a3de646a20021a"
 dependencies = [
  "burn",
  "itertools 0.12.1",
  "log",
  "ndarray",
  "ndarray-rand",
+ "priority-queue",
  "rand",
  "rayon",
  "serde",
@@ -1578,7 +1578,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2077,7 +2077,7 @@ dependencies = [
  "markup5ever",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2818,7 +2818,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3019,7 +3019,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3057,7 +3057,7 @@ checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -3126,12 +3126,23 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "910d41a655dac3b764f1ade94821093d3610248694320cd072303a8eedcf221d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.79",
+ "syn 2.0.82",
+]
+
+[[package]]
+name = "priority-queue"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714c75db297bc88a63783ffc6ab9f830698a6705aa0201416931759ef4c8183d"
+dependencies = [
+ "autocfg",
+ "equivalent",
+ "indexmap",
 ]
 
 [[package]]
@@ -3166,9 +3177,9 @@ checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3176,13 +3187,13 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -3191,28 +3202,28 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.79",
+ "syn 2.0.82",
  "tempfile",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
 name = "prost-reflect"
-version = "0.12.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057237efdb71cf4b3f9396302a3d6599a92fa94063ba537b66130980ea9909f3"
+checksum = "4b7535b02f0e5efe3e1dbfcb428be152226ed0c66cad9541f2274c8ba8d4cd40"
 dependencies = [
  "once_cell",
  "prost",
@@ -3221,9 +3232,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
 dependencies = [
  "prost",
 ]
@@ -3859,14 +3870,14 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -3892,7 +3903,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4048,7 +4059,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4148,7 +4159,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4161,7 +4172,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4183,9 +4194,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4215,7 +4226,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4310,7 +4321,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4423,7 +4434,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4571,7 +4582,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -4694,7 +4705,7 @@ checksum = "1ed7f4237ba393424195053097c1516bd4590dc82b84f2f97c5c69e12704555b"
 dependencies = [
  "proc-macro-hack",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "unic-langid-impl",
 ]
 
@@ -4809,16 +4820,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "utime"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91baa0c65eabd12fcbdac8cc35ff16159cab95cae96d0222d6d0271db6193cef"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "uuid"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4902,7 +4903,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "wasm-bindgen-shared",
 ]
 
@@ -4936,7 +4937,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5200,7 +5201,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5211,7 +5212,7 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5502,7 +5503,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "synstructure",
 ]
 
@@ -5524,7 +5525,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -5544,7 +5545,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "synstructure",
 ]
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison
-VERSION_NAME=0.1.43-anki24.10beta3
+VERSION_NAME=0.1.43-anki24.10rc1
 
 POM_INCEPTION_YEAR=2020
 

--- a/rslib-bridge/Cargo.toml
+++ b/rslib-bridge/Cargo.toml
@@ -16,7 +16,7 @@ gag = "1.0.0"
 jni = { version = "0.21.1", default-features = false }
 log = "0.4.20"
 once_cell = "1.18.0"
-prost = "0.12"
+prost = "0.13"
 tracing = { version = "0.1.39", features = ["max_level_trace", "release_max_level_debug", "log"] }
 
 [build-dependencies]
@@ -28,7 +28,7 @@ anki_i18n = { version = "0.0.0", path = "../anki/rslib/i18n" }
 anyhow = "1.0.75"
 glob = "0.3.1"
 inflections = "1.1.1"
-prost-reflect = "0.12.0"
-prost-types = "0.12.1"
+prost-reflect = "0.14.0"
+prost-types = "0.13"
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.107"


### PR DESCRIPTION

currently not working locally, posting for inspection, needs a proto.rs update in rsdroid ?

```
   Compiling rsdroid v0.1.0 (/Users/mike/work/ankidroid/Anki-Android-Backend/rslib-bridge)
error[E0308]: mismatched types
   --> rslib-bridge/proto.rs:64:65
    |
64  |     let (input_params, input_assign) = maybe_destructured_input(&input);
    |                                        ------------------------ ^^^^^^ expected `MessageDescriptor`, found `prost_reflect::descriptor::MessageDescriptor`
    |                                        |
    |                                        arguments to this function are incorrect
    |
    = note: `prost_reflect::descriptor::MessageDescriptor` and `MessageDescriptor` have similar names, but are actually distinct types
note: `prost_reflect::descriptor::MessageDescriptor` is defined in crate `prost_reflect`
   --> /Users/mike/.cargo/registry/src/index.crates.io-6f17d22bba15001f/prost-reflect-0.14.2/src/descriptor/mod.rs:195:1
    |
195 | pub struct MessageDescriptor {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: `MessageDescriptor` is defined in crate `prost_reflect`
   --> /Users/mike/.cargo/registry/src/index.crates.io-6f17d22bba15001f/prost-reflect-0.12.0/src/descriptor/mod.rs:195:1
    |
195 | pub struct MessageDescriptor {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `prost_reflect` are being used?
note: function defined here
   --> rslib-bridge/proto.rs:94:4
    |
94  | fn maybe_destructured_input(input: &MessageDescriptor) -> (String, String) {
    |    ^^^^^^^^^^^^^^^^^^^^^^^^ -------------------------

error[E0308]: mismatched types
   --> rslib-bridge/proto.rs:66:79
    |
66  |     let (output_msg_or_single_field, output_type) = maybe_destructured_output(&output);
    |                                                     ------------------------- ^^^^^^^ expected `MessageDescriptor`, found `prost_reflect::descriptor::MessageDescriptor`
    |                                                     |
    |                                                     arguments to this function are incorrect
    |
    = note: `prost_reflect::descriptor::MessageDescriptor` and `MessageDescriptor` have similar names, but are actually distinct types
note: `prost_reflect::descriptor::MessageDescriptor` is defined in crate `prost_reflect`
   --> /Users/mike/.cargo/registry/src/index.crates.io-6f17d22bba15001f/prost-reflect-0.14.2/src/descriptor/mod.rs:195:1
    |
195 | pub struct MessageDescriptor {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: `MessageDescriptor` is defined in crate `prost_reflect`
   --> /Users/mike/.cargo/registry/src/index.crates.io-6f17d22bba15001f/prost-reflect-0.12.0/src/descriptor/mod.rs:195:1
    |
195 | pub struct MessageDescriptor {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `prost_reflect` are being used?
note: function defined here
   --> rslib-bridge/proto.rs:153:4
    |
153 | fn maybe_destructured_output(output: &MessageDescriptor) -> (String, String) {
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^ --------------------------

error[E0308]: mismatched types
   --> rslib-bridge/build.rs:19:54
    |
19  |     let (_, services) = anki_proto_gen::get_services(&pool);
    |                         ---------------------------- ^^^^^ expected `prost_reflect::descriptor::DescriptorPool`, found `DescriptorPool`
    |                         |
    |                         arguments to this function are incorrect
    |
    = note: `DescriptorPool` and `prost_reflect::descriptor::DescriptorPool` have similar names, but are actually distinct types
note: `DescriptorPool` is defined in crate `prost_reflect`
   --> /Users/mike/.cargo/registry/src/index.crates.io-6f17d22bba15001f/prost-reflect-0.12.0/src/descriptor/mod.rs:134:1
    |
134 | pub struct DescriptorPool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
note: `prost_reflect::descriptor::DescriptorPool` is defined in crate `prost_reflect`
   --> /Users/mike/.cargo/registry/src/index.crates.io-6f17d22bba15001f/prost-reflect-0.14.2/src/descriptor/mod.rs:134:1
    |
134 | pub struct DescriptorPool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `prost_reflect` are being used?
note: function defined here
   --> /Users/mike/work/ankidroid/Anki-Android-Backend/anki/rslib/proto_gen/src/lib.rs:46:8
    |
46  | pub fn get_services(pool: &DescriptorPool) -> (Vec<CollectionService>, Vec<BackendService>) {
    |        ^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0308`.
error: could not compile `rsdroid` (build script) due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
note: If the build failed due to a missing target, you can run this command:
note: 
note:     rustup target install aarch64-linux-android

```