### PR TITLE
Include list of TS backend calls in artifacts directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,7 +526,12 @@ dependencies = [
  "anki_process",
  "anyhow",
  "camino",
+ "cc",
  "glob",
+ "streaming-iterator",
+ "tree-sitter",
+ "tree-sitter-svelte-ng",
+ "tree-sitter-typescript",
  "which",
 ]
 
@@ -4109,6 +4114,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4622,6 +4633,45 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9871f16d6cf5c4757dcf30d5d2172a2df6987c510c017bbb7abfb7f9aa24d06"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax 0.8.5",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ddffe35a0e5eeeadf13ff7350af564c6e73993a24db62caee1822b185c2600"
+
+[[package]]
+name = "tree-sitter-svelte-ng"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0a71f9cf5e94373cc86c64893630c8a29bb25d3390a248268d08af2165fa37"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aecf1585ae2a9dddc2b1d4c0e2140b2ec9876e2a25fd79de47fcf7dae0384685"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/build_rust/Cargo.toml
+++ b/build_rust/Cargo.toml
@@ -5,10 +5,17 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[build-dependencies]
+cc="*"
+
 [dependencies]
 anki_io = { version = "0.0.0", path = "../anki/rslib/io" }
 anki_process = { version = "0.0.0", path = "../anki/rslib/process" }
 anyhow = "1.0.75"
 camino = "1.1.6"
 glob = "0.3.1"
+streaming-iterator = "0.1.9"
+tree-sitter = "0.24.3"
+tree-sitter-svelte-ng = "1.0.2"
+tree-sitter-typescript = "0.23.0"
 which = "4.4.2"

--- a/build_rust/tree_sitter_queries/ts_imports.scm
+++ b/build_rust/tree_sitter_queries/ts_imports.scm
@@ -1,0 +1,16 @@
+; Match typical import of a backend function in Anki, following this format:
+; import { importDone } from "@generated/backend";
+(import_statement
+    (import_clause
+        (named_imports
+            (import_specifier
+                ; First capture
+                name: (identifier) @name
+            )
+        )
+    )
+    ; Second capture
+    source: (string) @src
+)
+
+; Add more ways of matching imports as necessary.

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison
-VERSION_NAME=0.1.43-anki24.10rc2
+VERSION_NAME=0.1.44-anki24.10rc2
 
 POM_INCEPTION_YEAR=2020
 


### PR DESCRIPTION
Currently we have no way of knowing what backend functions we should support for the TS scripts in the Anki backend, beyond manually checking the code. This PR adds a list of function names that we should have bindings for in [PostRequestHandler.kt](https://github.com/ankidroid/Anki-Android/blob/main/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt), to the Anki artifacts directory in a file named "ts_funcs.txt". In the Anki-Android repo, we should add a test to verify that the keys of our mappings in PostRequestHandler correlate to the list in the artifact directory.
Also, we can use the crates from this PR (oxc_*) for other TS-related things. Considering the fact that the Anki ecosystem is moving to TS+Svelte, it could very well come in handy in the future.