### PR TITLE
fix: scan all svelte not just routes

### DIFF
--- a/build_rust/src/main.rs
+++ b/build_rust/src/main.rs
@@ -100,7 +100,7 @@ fn build_web_artifacts() -> Result<()> {
     let mut ts_code = vec![];
     ts_code.append(&mut ts_all_scripts(Path::new("anki/ts")).unwrap());
     // Also include scripts inside of Svelte files.
-    ts_code.append(&mut svelte_all_scripts(Path::new("anki/ts/routes")).unwrap());
+    ts_code.append(&mut svelte_all_scripts(Path::new("anki/ts")).unwrap());
     for script_code in ts_code {
         // Get all of the imported backend funcs from the code.
         ts_funcs.extend(ts_imported_funcs(script_code, &query).unwrap());

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison
-VERSION_NAME=0.1.45-anki24.10rc2
+VERSION_NAME=0.1.46-anki24.10rc2
 
 POM_INCEPTION_YEAR=2020
 


### PR DESCRIPTION

when I pushed the version number in PR #437 I messed up the root of the scan for svelte code

This undoes that mistake