### PR TITLE
release: use 24.11rc1 (locally, add SYNC_SERVER_MESSAGE handling)

### DIFF
--- a/build_rust/src/main.rs
+++ b/build_rust/src/main.rs
@@ -8,7 +8,6 @@ use std::env;
 use std::env::consts::OS;
 use std::fs;
 use std::io::{self, Write};
-use std::ops::Deref;
 use std::path::Path;
 use std::process::Command;
 use streaming_iterator::StreamingIterator;

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison
-VERSION_NAME=0.1.46-anki24.10rc2
+VERSION_NAME=0.1.47-anki24.11rc1
 
 POM_INCEPTION_YEAR=2020
 

--- a/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/BackendForTesting.kt
+++ b/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/BackendForTesting.kt
@@ -30,7 +30,7 @@ class BackendForTesting(langs: Iterable<String>) : Backend(langs) {
     }
 
     enum class ErrorType {
-        InvalidInput, TemplateError, DbErrorFileTooNew, DbErrorFileTooOld, DbErrorMissingEntity, DbErrorCorrupt, DbErrorLocked, DbErrorOther, NetworkError, SyncErrorAuthFailed, SyncErrorOther, JSONError, ProtoError, Interrupted, CollectionNotOpen, CollectionAlreadyOpen, NotFound, Existing, FilteredDeckError, SearchError, FatalError
+        InvalidInput, TemplateError, DbErrorFileTooNew, DbErrorFileTooOld, DbErrorMissingEntity, DbErrorCorrupt, DbErrorLocked, DbErrorOther, NetworkError, SyncErrorAuthFailed, SyncErrorOther, SyncErrorServerMessage, JSONError, ProtoError, Interrupted, CollectionNotOpen, CollectionAlreadyOpen, NotFound, Existing, FilteredDeckError, SearchError, FatalError
     }
 
     companion object {

--- a/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/ExceptionTest.kt
+++ b/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/ExceptionTest.kt
@@ -104,6 +104,10 @@ class ExceptionTest {
                         BackendForTesting.ErrorType.SyncErrorOther,
                         BackendSyncException::class.java
                     ),
+                    arrayOf(
+                        BackendForTesting.ErrorType.SyncErrorServerMessage,
+                        BackendSyncException.BackendSyncServerMessageException::class.java
+                    ),
                     arrayOf(BackendForTesting.ErrorType.DbErrorCorrupt, NOT_POSSIBLE),
                     arrayOf(
                         BackendForTesting.ErrorType.DbErrorFileTooNew,

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendException.kt
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendException.kt
@@ -22,6 +22,7 @@ import android.database.sqlite.SQLiteFullException
 import anki.backend.BackendError
 import net.ankiweb.rsdroid.exceptions.*
 import net.ankiweb.rsdroid.exceptions.BackendSyncException.BackendSyncAuthFailedException
+import net.ankiweb.rsdroid.exceptions.BackendSyncException.BackendSyncServerMessageException
 import java.util.*
 import java.util.regex.Pattern
 
@@ -105,6 +106,7 @@ open class BackendException : RuntimeException {
                 BackendError.Kind.JSON_ERROR -> return BackendJsonException(error)
                 BackendError.Kind.SYNC_AUTH_ERROR -> return BackendSyncAuthFailedException(error)
                 BackendError.Kind.SYNC_OTHER_ERROR -> return BackendSyncException(error)
+                BackendError.Kind.SYNC_SERVER_MESSAGE -> return BackendSyncServerMessageException(error)
                 BackendError.Kind.ANKIDROID_PANIC_ERROR -> return BackendFatalError(error)
                 BackendError.Kind.EXISTS -> return BackendExistingException(error)
                 BackendError.Kind.FILTERED_DECK_ERROR -> return BackendDeckIsFilteredException(error)

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendSyncException.kt
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendSyncException.kt
@@ -20,4 +20,5 @@ import net.ankiweb.rsdroid.BackendException
 
 open class BackendSyncException(error: BackendError?) : BackendException(error!!) {
     class BackendSyncAuthFailedException(error: BackendError?) : BackendSyncException(error)
+    class BackendSyncServerMessageException(error: BackendError?) : BackendSyncException(error)
 }


### PR DESCRIPTION

Adopts the new upstream version, with the locally-interesting change being the split-out handling of new SYNC_SERVER_MESSAGE

I...think I did that correctly? Extra eyes + strict review keenly desired