### PR TITLE
docs: Improve error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ python
 
 # rust build files
 target
+
+# Ignore kotlin 2.0 compiler files (.salive: session-is-alive)
+# https://github.com/JetBrains/kotlin/blob/ca34e5d2fd255ed0501bae4fae3d3691dc40d375/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt#L458
+/.kotlin

--- a/build_rust/src/main.rs
+++ b/build_rust/src/main.rs
@@ -23,7 +23,8 @@ fn main() -> Result<()> {
     }
     let ndk_path = Utf8PathBuf::from(env::var("ANDROID_NDK_HOME").unwrap_or_default());
     if !ndk_path.file_name().unwrap_or_default().starts_with("27.") {
-        panic!("Expected ANDROID_NDK_HOME to point to a 27.x NDK. Future versions may work, but are untested.");
+        // Future NDKs may work, but are untested.
+        panic!("error: ANDROID_NDK_HOME must point to a 27.x NDK.");
     }
 
     build_web_artifacts()?;

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -35,13 +35,19 @@ def getFsrsVersion = { ->
     ".packages[] | select(.name==\"fsrs\") | .version"
     def verStdout = new ByteArrayOutputStream()
     def verStdin = new ByteArrayInputStream(pkgStdout.toByteArray())
-    exec {
-        // use "jaq" cargo module installed during rust build: self-contained + cross-platform
-        // if we use `jq` we are dependent on local system utility installation status
-        commandLine "jaq", verArgs
-        standardInput = verStdin
-        standardOutput = verStdout
+
+    try {
+        exec {
+            // use "jaq" cargo module installed during rust build: self-contained + cross-platform
+            // if we use `jq` we are dependent on local system utility installation status
+            commandLine "jaq", verArgs
+            standardInput = verStdin
+            standardOutput = verStdout
+        }
+    } catch (ex) {
+        throw new IOException("'jaq' failed. Ensure you followed the build instructions", ex)
     }
+
 
     def version = verStdout.toString().trim().replace("\"", "")
     println("FSRS version: ${version}")


### PR DESCRIPTION
* Improve the error message when missing `jaq`

<img width="1117" alt="Screenshot 2024-11-08 at 20 03 51" src="https://github.com/user-attachments/assets/64267b63-fc86-4885-a42c-cd2a4016658b">

* Fixes #440


----


Removed `.salive`, copied from: https://github.com/ankidroid/Anki-Android/commit/bebf14fecef69dfc6afb81909eaaf6dea133664d

----

Improved the NDK error message

```diff
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/build_rust`
thread 'main' panicked at build_rust/src/main.rs:25:9:
- Expected ANDROID_NDK_HOME to point to a 27.x NDK. Future versions may work, but are untested.
+ error: ANDROID_NDK_HOME must point to a 27.x NDK.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

