### PR TITLE
fix: adopt anki 24.11rc2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison
-VERSION_NAME=0.1.47-anki24.11rc1
+VERSION_NAME=0.1.47-anki24.11rc2
 
 POM_INCEPTION_YEAR=2020
 


### PR DESCRIPTION

built cleanly but only I after I did this locally:

> cd anki && git clean -d -x -f

Before that there was some issue with (apparently cached?) `portal.ts` in svelte area, which has been moved to a component