### PR TITLE
release: anki24.11 upstream with one commit more to fix an issue

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison
-VERSION_NAME=0.1.47-anki24.11rc2
+VERSION_NAME=0.1.48-anki24.11
 
 POM_INCEPTION_YEAR=2020
 


### PR DESCRIPTION
so that one bumps our local number

Here's what is in it, just to be clear - the upstream 24.11 tag then the one commit to fix stats deck button clickability from https://github.com/ankitects/anki/pull/3602

```
mike@isabela:~/work/ankidroid/Anki-Android-Backend/anki (fix/cant-select-deck) % git log --format=oneline
c47638ca36f99dd4f3b81ae82d964aec66e392e0 (HEAD -> fix/cant-select-deck) fix deck button not clickable in stats screen
87ccd24efd0ea635558b1679614b6763e4f514eb (tag: 24.11rc2, tag: 24.11, origin/main, origin/HEAD) Update translations
6874440cdad97185c13cb37f717bcd787fe2c445 Fix/incorrect memory state inference for incomplete review history (#3599)
67e7bf166027c4e9e0c5bb7fd778d38f44038512 Bump @sveltejs/kit from 2.7.3 to 2.8.3 (#3598)
13865dc0bbd0db007939a38fc16f407b2886cd27 Rust updates for CVE and yanked package
2cd6b1c3b79201fbed6fc93161b999300ab19470 Fix congrats screen not refreshing (#3594)
9a013d8601acd12f7518e0e1ba47cb5381a2ba15 Fix/FSRS progress sometime shows 0 reviews (#3591)
69ac450098518a39a1d955102a33c927281447d9 "Fields for ..."
3c20b49ccac4da63a85bf65b89af845d1f4851fb Bump cross-spawn from 7.0.3 to 7.0.6 (#3590)
4486227178fad5bb1b50f12d281a1d13f984f7a3 Bump mimalloc for CVE
01c368654b502c0c585380ff439dd9060b455b3b Remove remaining remnants of unused error; fix CI
15fde0426454f50f6aae10d0f83be6f02cead4d1 Bump rust base image `1.80.1` to `1.82.0` (#3587)
e992d6d462074050781bdc53a97c9c1a91adeaa6 Fix/inconsistent retrievability calculations between normal/filtered decks and display/sorting (#3582)
1c3754f6c795a54ea2b91ce2030f640ae5a1a9b7 Improve wording of optimal retention tooltip (#3579)
db1280e6ae6a0547f8310f30ed6412e9b5ed0db3 Exclude new cards from Future Due stats (#3576)
2cbb6484560730510e8d2165eaff03661ef1ebb5 Fix editor width changing as tag completions shown (#3574)
b933796a5155738cde49f55b63265ac8e8f7f8f2 Fix setting tags column to first unmapped column (#3568)
03c50c8332850af2260ebd828801f7992c2a0972 Do not show warning if Browser Appearance has no field references (#3566)
```