### PR TITLE
feat: adopt anki25.01beta1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "1.4.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de570dbbc7b95c5cf5f77c905b3b54b16352c1b48694e6761d716fb92b8db67c"
+checksum = "b444b46751c2196ed329f3e577e8a693b948d9d0f07c237473c15dead8d7000e"
 dependencies = [
  "burn",
  "itertools 0.12.1",

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison
-VERSION_NAME=0.1.48-anki24.11
+VERSION_NAME=0.1.48-anki25.01beta1
 
 POM_INCEPTION_YEAR=2020
 


### PR DESCRIPTION

This had local build failures for me on macOS due to a missing `cairo/cairo.h` header file included in the node dependency `canvas`.

I actually have cairo installed on my mac and I made no good headway within my timebox to figure out why it wasn't being seen. I do have a fairly custom node setup locally though, and that *may* be the culprit

So, I'm tossing it into CI to see what happens there in stock setups of everything