### PR TITLE
build: add diagnostics for windows jaq install hang

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -9,13 +9,16 @@ on:
   push:
     branches:
       - main
+  merge_group:
 
 env:
   DEBUG: 1
   ANDROID_NDK_VERSION: "27.0.12077973"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # if a workflow is run against the same ref, only one at a time...
+  # ...but allow different triggers to run concurrent (push, manual flake run, scheduled flake run...)
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,6 +14,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
 
 env:
   ALL_ARCHS: 1
@@ -22,7 +23,7 @@ env:
   ANDROID_NDK_VERSION: "27.0.12077973"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.mavenPublish }}-release
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.event.inputs.mavenPublish }}-release
   cancel-in-progress: true
 
 jobs:

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -26,10 +26,10 @@ def getFsrsVersion = { ->
     def crateInfo = providers.exec {
         commandLine "cargo", "install", "--list"
     }.standardOutput.asText.get()
-    if (!crateInfo.contains("jaq v1.6.0")) {
+    if (!crateInfo.contains("jaq v2.1.0")) {
         println("jaq rust crate not installed, needed to fetch FSRS version. Installing...")
         def jaqInstallProcess = new ProcessBuilder()
-                .command("cargo", "install", "jaq@1.6.0")
+                .command("cargo", "install", "jaq@2.1.0")
                 .redirectErrorStream(true)
                 .start()
         def jaqOutput = new BufferedReader(new InputStreamReader(jaqInstallProcess.getInputStream()))

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -28,7 +28,18 @@ def getFsrsVersion = { ->
     }.standardOutput.asText.get()
     if (!crateInfo.contains("jaq v1.6.0")) {
         println("jaq rust crate not installed, needed to fetch FSRS version. Installing...")
-        new ProcessBuilder().command("cargo", "install", "jaq@1.6.0").start().waitFor()
+        def jaqInstallProcess = new ProcessBuilder()
+                .command("cargo", "install", "jaq@1.6.0")
+                .redirectErrorStream(true)
+                .start()
+        def jaqOutput = new BufferedReader(new InputStreamReader(jaqInstallProcess.getInputStream()))
+        while (jaqInstallProcess.isAlive()) {
+            def jaqOutputLine = jaqOutput.readLine()
+            if (jaqOutputLine != null) {
+                System.out.println(jaqOutput.readLine())
+            }
+        }
+        jaqInstallProcess.waitFor()
     }
     def verStdin = providers.exec {
          commandLine "cargo", "metadata", "--locked", "--format-version=1", "--manifest-path=" + new File("${project.rootDir}", "anki/Cargo.toml")


### PR DESCRIPTION

Something is causing windows build to hang on the jaq crate install, this should help?

There is some chatter about sub-processes hanging just by not having their stdout/stderr consumed in windows, so I may affect the hang (and effectively solve it) simply now consuming the output. But if not then we'll have the output to examine anyway

Also updates jaq to 2.1.0, which may also inadvertently solve it, because perhaps jaq was already installed but an older version before - so install never really happened so there was no problem with the install - but now that 2.1.0 is out an 1.6.0 is maybe not installed the nstall was happening and causing the problem

All  know is I want the windows build in CI to work again. It was working for me in windows when I tried to reproduce, so I'm not really sure what's going on

