### PR TITLE
build: convert settings.gradle to Kotlin DSL

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,0 @@
-include ':rsdroid-testing'
-include ':rsdroid-instrumented'
-include ':rsdroid'
-rootProject.name = "Anki-Android-Backend"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "Anki-Android-Backend"
+
+include(":rsdroid-testing", ":rsdroid-instrumented", ":rsdroid")


### PR DESCRIPTION
We were having problems with dependabot not detecting dependencies in:

* #463

This only affected dependencies in subprojects

This is an attempt to fix it