### PR TITLE
build(ci): caches no longer need versions to evict

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -144,9 +144,9 @@ jobs:
             anki/out/rust
             anki/out/download
             # no node_modules, as it doesn't unpack properly
-          key: ${{ runner.os }}-rust-debug-v7-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
+          key: ${{ runner.os }}-rust-debug-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-rust-debug-v7
+            ${{ runner.os }}-rust-debug
 
       - name: Restore Rust Cache (Unix)
         uses: actions/cache/restore@v4
@@ -159,9 +159,9 @@ jobs:
             anki/out/rust
             anki/out/download
             anki/out/node_modules
-          key: ${{ runner.os }}-rust-debug-v6-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
+          key: ${{ runner.os }}-rust-debug-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-rust-debug-v6
+            ${{ runner.os }}-rust-debug
 
       - name: Setup N2
         run: bash ./anki/tools/install-n2
@@ -256,7 +256,7 @@ jobs:
             anki/out/rust
             anki/out/download
             # no node_modules, as it doesn't unpack properly
-          key: ${{ runner.os }}-rust-debug-v7-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
+          key: ${{ runner.os }}-rust-debug-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
 
       - name: Save Rust Cache (Unix)
         uses: actions/cache/save@v4
@@ -269,4 +269,4 @@ jobs:
             anki/out/rust
             anki/out/download
             anki/out/node_modules
-          key: ${{ runner.os }}-rust-debug-v6-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
+          key: ${{ runner.os }}-rust-debug-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -70,9 +70,9 @@ jobs:
             anki/out/rust
             anki/out/extracted
             anki/out/node_modules
-          key: ${{ runner.os }}-rust-release-v7-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
+          key: ${{ runner.os }}-rust-release-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-rust-release-v7
+            ${{ runner.os }}-rust-release
 
       - name: Setup N2
         run: ./anki/tools/install-n2
@@ -149,4 +149,4 @@ jobs:
             anki/out/rust
             anki/out/download
             anki/out/node_modules
-          key: ${{ runner.os }}-rust-release-v7-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
+          key: ${{ runner.os }}-rust-release-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -111,9 +111,9 @@ jobs:
           anki/out/rust
           anki/out/download
           anki/out/node_modules
-        key: ${{ runner.os }}-rust-debug-v6-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
+        key: ${{ runner.os }}-rust-debug-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('anki/yarn.lock') }}
         restore-keys: |
-          ${{ runner.os }}-rust-debug-v6
+          ${{ runner.os }}-rust-debug
 
     - name: Setup N2
       if: matrix.build-mode == 'manual'


### PR DESCRIPTION

Examining:
- #363 

- now that github web UI has ability to remove caches manually, that is the preferred method to force a cache miss / rebuild, versions numbers are an obsolete strategy

It appears that publish was just run at the same time as release build was running on the last commit pushed to main, I'm not sure there is a problem here based on examination of last few runs of the various workflows, but I'll see how this behaves once merged as it changes all the keys

Note that cache saves only happen on main branch builds (so that non-main builds don't evict the cache LRU-style with too much storage requirement vs available cache space) - so this will only affect things once merged