### PR TITLE
build: extract ndkVersion to libs.versions.toml

### DIFF
--- a/build-rust.gradle
+++ b/build-rust.gradle
@@ -2,7 +2,7 @@ tasks.register('buildRust', Exec) {
     // ensure script doesn't try to start gradle again
     environment 'RUNNING_FROM_GRADLE', '1'
     if (!System.getenv('ANDROID_NDK_HOME')) {
-        String ndkPath = "${getSdkDir()}/ndk/27.0.12077973"
+        String ndkPath = "${getSdkDir()}/ndk/${libs.versions.ndkVersion.get()}"
         environment 'ANDROID_NDK_HOME', ndkPath
     }
     workingDir "$rootDir"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,9 @@
 compileSdk = "34"
 targetSdk = "34"
 minSdk = "21"
-
+# WARN: this is not yet consolidated. Manually replace when updating
+# Used by GitHub Actions - avoids an install step on some machines
+ndkVersion = "27.0.12077973"
 
 # https://developer.android.com/jetpack/androidx/releases/appcompat
 androidxAppCompat = "1.7.0"

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -81,7 +81,7 @@ static def getBackendGitCommitHash() {
 android {
     namespace = 'net.ankiweb.rsdroid'
     compileSdk = libs.versions.compileSdk.get().toInteger()
-    ndkVersion = "27.0.12077973" // Used by GitHub actions - avoids an install step on some machines
+    ndkVersion = libs.versions.ndkVersion.get()
 
     buildFeatures {
         buildConfig = true // expose 'ANKI_DESKTOP_VERSION'


### PR DESCRIPTION
Fixes part of issue #467: ndkVersion consolidation

toml introduced in df1adedda82f9ef13ac7be613e910e1571b96ba0

* #467