### PR TITLE
fix(deps): define NDK version in a single spot, use dynamically everywhere

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -13,7 +13,6 @@ on:
 
 env:
   DEBUG: 1
-  ANDROID_NDK_VERSION: "27.0.12077973"
 
 concurrency:
   # if a workflow is run against the same ref, only one at a time...
@@ -108,6 +107,13 @@ jobs:
 
       - name: Fetch submodules
         run: git submodule update --init
+
+      - name: Read configured NDK version
+        run: |
+          cargo install toml-cli
+          ANDROID_NDK_VERSION=$(toml get gradle/libs.versions.toml versions.ndk --raw)
+          echo "ANDROID_NDK_VERSION=$ANDROID_NDK_VERSION" >> $GITHUB_ENV
+        shell: bash
 
       - name: Install/Set NDK version (Unix)
         if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,7 +20,6 @@ env:
   ALL_ARCHS: 1
   RELEASE: 1
   CARGO_PROFILE_RELEASE_LTO: fat
-  ANDROID_NDK_VERSION: "27.0.12077973"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.event.inputs.mavenPublish }}-release
@@ -35,6 +34,13 @@ jobs:
 
       - name: Fetch submodules
         run: git submodule update --init
+
+      - name: Read configured NDK version
+        run: |
+          cargo install toml-cli
+          ANDROID_NDK_VERSION=$(toml get gradle/libs.versions.toml versions.ndk --raw)
+          echo "ANDROID_NDK_VERSION=$ANDROID_NDK_VERSION" >> $GITHUB_ENV
+        shell: bash
 
       - name: Install/Set NDK version
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -87,9 +87,20 @@ jobs:
       if: matrix.build-mode == 'manual'
       run: git submodule update --init
 
-    - name: Set NDK version (Unix)
+    - name: Read configured NDK version
+      run: |
+        cargo install toml-cli
+        ANDROID_NDK_VERSION=$(toml get gradle/libs.versions.toml versions.ndk --raw)
+        echo "ANDROID_NDK_VERSION=$ANDROID_NDK_VERSION" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Install/Set NDK version
       if: matrix.build-mode == 'manual'
       run: |
+        export PATH="$PATH:$ANDROID_HOME/cmdline-tools/latest/bin"
+        ./.github/scripts/install_ndk.sh ${ANDROID_NDK_VERSION}
+        ./.github/scripts/purge_ndk.sh ${ANDROID_NDK_VERSION}
+        export ANDROID_NDK_LATEST_HOME="${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}"
         echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
         echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
 

--- a/.github/workflows/update_gradle_wrapper.yml
+++ b/.github/workflows/update_gradle_wrapper.yml
@@ -26,10 +26,17 @@ jobs:
     - name: Install Android Command Line Tools
       uses: android-actions/setup-android@v3
 
+    - name: Read configured NDK version
+      run: |
+        cargo install toml-cli
+        ANDROID_NDK_VERSION=$(toml get gradle/libs.versions.toml versions.ndk --raw)
+        echo "ANDROID_NDK_VERSION=$ANDROID_NDK_VERSION" >> $GITHUB_ENV
+      shell: bash
+
     # COULD_BE_BETTER: Consider turning this into a GitHub action - help the wider community
     # NDK install (unzipping) is really noisy - silence the log spam with grep, while keeping errors
     - name: Install NDK (silent)
-      run: .github/scripts/install_ndk.sh 27.0.12077973
+      run: .github/scripts/install_ndk.sh $ANDROID_NDK_VERSION
 
     - name: Update Gradle Wrapper
       uses: gradle-update/update-gradle-wrapper-action@v2

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ On Windows:
 In Android Studio, choose the Tools>SDK Manager menu option.
 
 - In SDK tools, enable "show package details"
-- Choose NDK version 27.0.12077973
+- Choose NDK version listed in `gradle/libs.versions.tml` for the `ndk` key
 - After downloading, you may need to restart Android Studio to get it to
 synchronize gradle.
 
@@ -81,21 +81,29 @@ to tell the script to use the Java libraries and NDK downloaded by Android Studi
 eg on Linux:
 
 ```
+cargo install toml-cli
+ANDROID_NDK_VERSION=$(toml get gradle/libs.versions.toml versions.ndk --raw)
 export ANDROID_SDK_ROOT=$HOME/Android/Sdk
-export ANDROID_NDK_HOME=$HOME/Android/Sdk/ndk/27.0.12077973
+export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION
 ```
 
 Or macOS:
 
 ```
+cargo install toml-cli
+ANDROID_NDK_VERSION=$(toml get gradle/libs.versions.toml versions.ndk --raw)
 export ANDROID_SDK_ROOT=$HOME/Library/Android/sdk
-export ANDROID_NDK_HOME=$HOME/Library/Android/sdk/ndk/27.0.12077973
+export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION
 ```
+
 Or Windows using Powershell:
 
 ```
-$env:ANDROID_NDK_HOME="$env:ANDROID_SDK_ROOT\ndk\27.0.12077973"
+cargo install toml-cli
+$env:ANDROID_NDK_VERSION=toml get gradle/libs.versions.toml versions.ndk --raw
+$env:ANDROID_NDK_HOME="$env:ANDROID_SDK_ROOT\ndk\$env:ANDROID_NDK_VERSION"
 ```
+
 If you don't have Java installed, you may be able to use the version bundled
 with Android Studio. Eg on macOS:
 

--- a/build-rust.gradle
+++ b/build-rust.gradle
@@ -1,10 +1,6 @@
 tasks.register('buildRust', Exec) {
     // ensure script doesn't try to start gradle again
     environment 'RUNNING_FROM_GRADLE', '1'
-    if (!System.getenv('ANDROID_NDK_HOME')) {
-        String ndkPath = "${getSdkDir()}/ndk/27.0.12077973"
-        environment 'ANDROID_NDK_HOME', ndkPath
-    }
     workingDir "$rootDir"
     commandLine "cargo", "run", "-p", "build_rust"
 }

--- a/build_rust/src/main.rs
+++ b/build_rust/src/main.rs
@@ -21,9 +21,8 @@ fn main() -> Result<()> {
         return Ok(());
     }
     let ndk_path = Utf8PathBuf::from(env::var("ANDROID_NDK_HOME").unwrap_or_default());
-    if !ndk_path.file_name().unwrap_or_default().starts_with("27.") {
-        // Future NDKs may work, but are untested.
-        panic!("error: ANDROID_NDK_HOME must point to a 27.x NDK.");
+    if !ndk_path.exists() {
+        panic!("error: ANDROID_NDK_HOME must point to your NDK installation.");
     }
 
     build_web_artifacts()?;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,8 @@ compileSdk = "34"
 targetSdk = "34"
 minSdk = "21"
 
+# https://developer.android.com/ndk/downloads
+ndk = "27.0.12077973"
 
 # https://developer.android.com/jetpack/androidx/releases/appcompat
 androidxAppCompat = "1.7.0"

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -81,7 +81,7 @@ static def getBackendGitCommitHash() {
 android {
     namespace = 'net.ankiweb.rsdroid'
     compileSdk = libs.versions.compileSdk.get().toInteger()
-    ndkVersion = "27.0.12077973" // Used by GitHub actions - avoids an install step on some machines
+    ndkVersion = libs.versions.ndk.get()
 
     buildFeatures {
         buildConfig = true // expose 'ANKI_DESKTOP_VERSION'

--- a/tools/doctor.sh
+++ b/tools/doctor.sh
@@ -35,6 +35,10 @@ cecho $lgray "##################################\n"
 cecho $lgray "Getting anki submodules"
 git submodule update --init
 
+which cargo || (
+  echo "Rustup should be installed"
+  exit 1
+)
 
 if [[ -n "$ANDROID_SDK_ROOT" ]]; then
   ok_echo "ANDROID_SDK_ROOT is set"
@@ -42,18 +46,15 @@ else
   error_echo "ANDROID_SDK_ROOT should point to your SDK installation"
 fi
 
+cargo install toml-cli
+ANDROID_NDK_VERSION=$(toml get gradle/libs.versions.toml versions.ndk --raw)
 
 if [[ -d "$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION" ]]; then
   ok_echo "NDK $ANDROID_NDK_VERSION directory found"
 else
   echo -e "Expected to find: $ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION"
-  error_echo "NDK $ANDROID_NDK_VERSION directory found"
+  error_echo "NDK $ANDROID_NDK_VERSION directory not found"
 fi
-
-which cargo || (
-  echo "Rustup should be installed"
-  exit 1
-))
 
 if [ "$(uname)" == "Darwin" ]; then
   # We do not want to run under Rosetta 2


### PR DESCRIPTION
Previously the NDK version we wanted to use was scattered in 14 spots.

One of the more thorough violations of the principal of "Don't Repeat Yourself" I've ever seen

- Fixes #467 

Once I get this through I'll do a follow-on where I try to adopt the newer v28 release of the ndk