### PR TITLE
test(ci): use !cancelled instead of always, avoid missing emu artifacts

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Upload rsdroid AAR as artifact
         uses: actions/upload-artifact@v4
-        if: ${{ always() }}
+        if: '!cancelled()'
         with:
           name: rsdroid-aar-${{ matrix.os }}
           if-no-files-found: error
@@ -225,7 +225,7 @@ jobs:
 
       - name: Upload rsdroid-robo JAR as artifact
         uses: actions/upload-artifact@v4
-        if: ${{ always() }}
+        if: '!cancelled()'
         with:
           name: rsdroid-robo-${{ matrix.os }}
           if-no-files-found: error
@@ -233,14 +233,14 @@ jobs:
 
       - name: Upload Emulator Log
         uses: actions/upload-artifact@v4
-        if: always()
+        if: ('!cancelled()' && contains(matrix.os, 'ubuntu'))
         with:
           name: ${{ matrix.name }}-adb_logs
           path: adb-log.txt
 
       - name: Upload Emulator Screen Record
         uses: actions/upload-artifact@v4
-        if: always()
+        if: ('!cancelled()' && contains(matrix.os, 'ubuntu'))
         with:
           name: ${{ matrix.name }}-adb_video
           path: video.webm


### PR DESCRIPTION
- always() status check also runs when runs are cancelled, but you don't want that, so it is recommended to use '!cancelled()' as an "always, unless cancelled"
- we were trying to upload emulater log / video on all platforms but it only runs on ubuntu

Testing:
If this is correct, we should see 
- 2 rsdroid artifacts for each of the three platforms, and 
- 2 emulator artifacts for ubuntu, and no artifact upload warnings