### PR TITLE
build(deps): adopt ndk v28 / add doc on CLI install of same

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ On Windows:
 
 ### NDK
 
+#### Command-line install
+
+Assuming `sdkmanager` from the "Command-Line Tools" package is in your PATH:
+
+```bash
+cargo install toml-cli
+ANDROID_NDK_VERSION=$(toml get gradle/libs.versions.toml versions.ndk --raw)
+sdkmanager --install "ndk;$ANDROID_NDK_VERSION"
+```
+
+#### GUI install
+
 In Android Studio, choose the Tools>SDK Manager menu option.
 
 - In SDK tools, enable "show package details"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ targetSdk = "34"
 minSdk = "21"
 
 # https://developer.android.com/ndk/downloads
-ndk = "27.0.12077973"
+ndk = "28.0.13004108"
 
 # https://developer.android.com/jetpack/androidx/releases/appcompat
 androidxAppCompat = "1.7.0"

--- a/rslib-bridge/build.rs
+++ b/rslib-bridge/build.rs
@@ -7,6 +7,7 @@ pub mod proto;
 use std::{
     env::{self, consts::OS},
     path::PathBuf,
+    process::Command,
 };
 
 use anyhow::Result;
@@ -33,10 +34,41 @@ fn main() -> Result<()> {
         } else {
             "windows-x86_64"
         };
-        let lib_dir = format!("/toolchains/llvm/prebuilt/{platform}/lib/clang/18/lib/linux/");
+
+        // cargo-ndk sets CC_x86_64-linux-android to the path to `clang`, within the
+        // Android NDK.
+        let clang_path = PathBuf::from(
+            env::var("CC_x86_64-linux-android").expect("CC_x86_64-linux-android not set"),
+        );
+        let clang_version = get_clang_major_version(&clang_path);
+
+        let lib_dir =
+            format!("/toolchains/llvm/prebuilt/{platform}/lib/clang/{clang_version}/lib/linux/");
         println!("cargo:rustc-link-search={android_ndk_home}/{lib_dir}");
         println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");
     }
 
     Ok(())
+}
+
+/// Run the clang binary at `clang_path`, and return its major version number
+fn get_clang_major_version(clang_path: &PathBuf) -> String {
+    let clang_output = Command::new(clang_path)
+        .arg("-dumpversion")
+        .output()
+        .expect("failed to start clang");
+
+    if !clang_output.status.success() {
+        panic!(
+            "failed to run clang: {}",
+            String::from_utf8_lossy(&clang_output.stderr)
+        );
+    }
+
+    let clang_version = String::from_utf8(clang_output.stdout).expect("clang output is not utf8");
+    clang_version
+        .split('.')
+        .next()
+        .expect("could not parse clang output")
+        .to_owned()
 }


### PR DESCRIPTION

does what the title says - ndk28 + a quick doc for CLI folks to install it quickly

works locally with Anki-Android via `local_backend=true`, everything *seems* fine

super easy now that #471 is in