### PR TITLE
build(deps): adopt ndk29

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ targetSdk = "34"
 minSdk = "21"
 
 # https://developer.android.com/ndk/downloads
-ndk = "28.0.13004108"
+ndk = "29.0.13113456"
 
 # https://developer.android.com/jetpack/androidx/releases/appcompat
 androidxAppCompat = "1.7.0"


### PR DESCRIPTION
note, this is not ready yet, but a final commit when it is released as stable should fix it up, and it already appears to work fine

Just posting it because I was in there and gave it a shot and it worked, posting it up to show this is all NDK bump takes now

