### PR TITLE
build: pre-test on windows-2025

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -36,7 +36,7 @@ jobs:
           script: |
             // by default, we will include all 3 platforms we test on
             // "latest" would be easy everywhere, but "macos-15" isn't "latest" so we are specific there
-            let osArray = ["ubuntu-latest", "macos-15", "windows-latest"]
+            let osArray = ["ubuntu-latest", "macos-15", "windows-2025"]
 
             let includeArray = [];
             for(const os of osArray) {


### PR DESCRIPTION

This is not an important PR, was just clearing notification queue and saw that windows-2025 was available as a runner

This PR is nothing more than a compatibility check. If it runs fine I will close it rather than put the change in as I prefer `-latest` tags, but if it fails to run for some reason then it bears investigation so we're ready whenever `windows-latest` moves to the windows-2025 runner