### PR TITLE
Add pre-commit format-rust

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+./format-rust.sh

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -170,6 +170,21 @@ tasks.withType(KotlinCompile).configureEach {
     }
 }
 
+
+
+// Install Git pre-commit hook for format-rust
+tasks.register('installGitHook', Copy) {
+    from new File(rootProject.rootDir, 'pre-commit')
+    into { new File(rootProject.rootDir, '.git/hooks') }
+    filePermissions {
+        user {
+            read = write = execute = true
+        }
+    }
+}
+// to run manually: `./gradlew installGitHook`
+tasks.named('preBuild').configure { dependsOn('installGitHook') }
+
 mavenPublishing {
     // Use https://central.sonatype.com/account with david-allison's GitHub login, not Google
     // the host should match rsdroid-testing


### PR DESCRIPTION
I've not found an already existing script to format the kotlin part. So I've only added the rust check right now. That would have avoided the delay in #505