### PR TITLE
fix(deps): adopt upstream anki 25.02.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison
-VERSION_NAME=0.1.52-anki25.02.4
+VERSION_NAME=0.1.52-anki25.02.5
 
 POM_INCEPTION_YEAR=2020
 


### PR DESCRIPTION
https://github.com/ankitects/anki/releases/tag/25.02.5

I don't think any of this affects us, but best to be current in case next one does