### PR TITLE
build(deps): adopt anki 25.02.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison
-VERSION_NAME=0.1.52-anki25.02.5
+VERSION_NAME=0.1.52-anki25.02.7
 
 POM_INCEPTION_YEAR=2020
 


### PR DESCRIPTION

does what the PR title says - simple bump to new tag on current stable release series from upstream

shouldn't affect us (it's all python / qt code), but we'll be up to date in case something important comes up later