### PR TITLE
feat: log panics as 'Error' in logcat

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -104,7 +104,7 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 0
           retry_on: error
-          command: cargo run -p build_rust
+          command: ./build.sh
 
       - name: Upload rsdroid AAR as artifact
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ Install Xcode/Visual Studio if on macOS/Windows.
 
 Install rustup from <https://rustup.rs/>
 
+#### macOS / Rust / Android Studio interaction
+
+Note that Android Studio does a gradle sync when you open Anki-Android-Backend as a project,
+and this sync requires the `cargo` command to be in your environment `PATH` variable to succeed.
+
+If you get an exception related to `cargo` not found, you may need to alter your environment
+before starting Android Studio. On macOS at least, you may open `Terminal`, verify `cargo` is
+in the `PATH` with a `which cargo`, and open Android Studio directly with this environment setup
+via the command `open -a "Android Studio"`
+
 ### Ninja
 
 Anki can be built with Ninja or N2. N2 gives better status output and may be installed like so:

--- a/check-rust.bat
+++ b/check-rust.bat
@@ -1,4 +1,8 @@
 rustup component add clippy
+
+@rem non-zero exit code on warnings
+set RUSTFLAGS=-Dwarnings
+
 cargo clippy
 cd anki\cargo\format
 cargo fmt --check --all --manifest-path ..\..\..\Cargo.toml

--- a/check-rust.sh
+++ b/check-rust.sh
@@ -2,5 +2,8 @@
 
 set -e
 
+# Non-zero exit on warnings
+export RUSTFLAGS="-Dwarnings"
+
 rustup component add clippy && cargo clippy
 (cd anki/cargo/format && cargo fmt --check --all --manifest-path ../../../Cargo.toml)

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison
-VERSION_NAME=0.1.52-anki25.06b1
+VERSION_NAME=0.1.53-anki25.06b1
 
 POM_INCEPTION_YEAR=2020
 

--- a/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/BackendPanicTests.kt
+++ b/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/BackendPanicTests.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.ankiweb.rsdroid
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import anki.notes.copy
+import anki.notes.note
+import net.ankiweb.rsdroid.BackendException.BackendFatalError
+import net.ankiweb.rsdroid.ankiutil.InstrumentedTest
+import net.ankiweb.rsdroid.rules.LogcatRule
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.not
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.empty
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.Assert.fail
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BackendPanicTests : InstrumentedTest() {
+    @get:Rule
+    val logcat = LogcatRule()
+
+    @Test
+    fun panicsAreLogcatErrors() {
+        panic(memoryBackend)
+
+        val errors = logcat.errors
+
+        assertThat("logcat has errors", errors, not(empty()))
+
+        // line 1: Panic at anki/rslib/src/storage/note/mod.rs:73: assertion `left == right` failed
+        assertThat(errors[0].message, containsString("Panic at "))
+        assertThat(errors[0].message, containsString("assertion `left == right` failed"))
+
+        assertThat(errors[1].message, equalTo("left: 1"))
+        assertThat(errors[2].message, equalTo("right: 0"))
+
+        assertThat("logcat has no more errors", errors, hasSize(3))
+    }
+
+    /** Causes future backend operations to throw a `PoisonError` */
+    private fun panic(backend: Backend): BackendFatalError {
+        panicExpected = true
+        val validNote = note {
+            fields.addAll(listOf("Hello", "World"))
+            notetypeId = backend.getNotetypeIdByName("Basic")
+        }
+
+        val invalidNote = validNote.copy { id = 1 }
+        try {
+            backend.addNote(invalidNote, deckId = 1)
+            fail("Expected BackendFatalError")
+            throw IllegalStateException("fail")
+        } catch (err: BackendFatalError) {
+            return err
+        }
+    }
+}

--- a/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/rules/LogcatRule.kt
+++ b/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/rules/LogcatRule.kt
@@ -1,0 +1,80 @@
+package net.ankiweb.rsdroid.rules
+
+import net.ankiweb.rsdroid.rules.LogcatRule.LogEntry.LogLevel
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+class LogcatRule : TestWatcher() {
+    val logs : List<LogEntry> get() = Logcat.dump()
+            .mapNotNull {
+                line -> logPattern.find(line)
+            }
+            .map { match ->
+                val (levelString, tag, message) = match.destructured
+                LogEntry(
+                    level = LogLevel.fromString(levelString),
+                    tag = tag,
+                    message = message,
+                    rawLine = match.value
+                )
+            }
+            .toList()
+
+    val errors get() = logs.filter { it.level == LogLevel.ERROR }
+
+
+    override fun starting(description: Description) {
+        Logcat.clear()
+    }
+
+    data class LogEntry(
+        val level: LogLevel,
+        val tag: String,
+        val message: String,
+        val rawLine: String
+    ) {
+
+        enum class LogLevel {
+            TRACE,
+            DEBUG,
+            INFO,
+            WARN,
+            // error and WTF
+            ERROR;
+
+            companion object {
+                fun fromString(string: String) =
+                    when (string) {
+                        "T" -> TRACE
+                        "D" -> DEBUG
+                        "I" -> INFO
+                        "W" -> WARN
+                        "E" -> ERROR
+                        else -> throw IllegalArgumentException("unexpected level: ${string}")
+                    }
+
+            }
+
+        }
+
+    }
+
+    companion object {
+        // 1:level; 2:tag; 3:message |    1 [        2      ] [         3           ]
+        // 06-14 14:17:18.600 25500 25524 I rsdroid::logging: rsdroid logging enabled
+        private val logPattern = Regex(""".* ([TDIWE]) (.+?)\s+(.+)$""")
+    }
+}
+
+private object Logcat {
+    fun clear() {
+        Runtime.getRuntime().exec("logcat -c")
+    }
+
+    fun dump() = sequence<String> {
+        val process = Runtime.getRuntime().exec("logcat -d")
+        process.inputStream.bufferedReader().use { reader ->
+            yieldAll(reader.lineSequence())
+        }
+    }
+}

--- a/rsdroid-testing/build.gradle
+++ b/rsdroid-testing/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 }
 
 jar {
-    dependsOn("buildRust")
+    mustRunAfter("buildRust")
     sourceSets {
         main {
             resources {


### PR DESCRIPTION
Previously these logs were 'debug', and therefore not in ACRA

* For https://github.com/ankidroid/Anki-Android/issues/18512

----

@dae requesting review 

* Could you confirm we're not going to receive email addresses in the panics 
  * if so, is there a good method of avoiding this. I believe we already filter server-side, but ideally don't want to transmit them at all
* (optional) A quick check of the Rust if you have time

----

* @mikehardy could I confirm we'd handle PII correctly if it was passed in via this PR
* https://github.com/ankidroid/Anki-Android/issues/17392
