### PR TITLE
build(deps): adopt upstream anki 25.06b6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison
-VERSION_NAME=0.1.56-anki25.06b5
+VERSION_NAME=0.1.56-anki25.06b6
 
 POM_INCEPTION_YEAR=2020
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # older versions may fail to compile; newer versions may fail the clippy tests
-channel = "1.85.0"
+channel = "1.87.0"


### PR DESCRIPTION
note, rust-toolchain bumped upstream, I simply mirror that here

ran ./check-rust.sh which sometimes bumps things in our Cargo.lock but it did no such thing, so this should be pretty simple and good to go once CI approves