### PR TITLE
build(deps): adopt ndk 28.2.13676358 (aka r28c)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison
-VERSION_NAME=0.1.57-anki25.07.1
+VERSION_NAME=0.1.58-anki25.07.1
 
 POM_INCEPTION_YEAR=2020
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ targetSdk = "34"
 minSdk = "21"
 
 # https://developer.android.com/ndk/downloads
-ndk = "28.1.13356709"
+ndk = "28.2.13676358"
 
 # https://developer.android.com/jetpack/androidx/releases/appcompat
 androidxAppCompat = "1.7.1"


### PR DESCRIPTION

does what it says on the tin

will collide with rn29 beta PR which is still waiting for a real release, this is tracking stable

- #496