### PR TITLE
build(deps): update to minSdk 23

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 compileSdk = "34"
 targetSdk = "34"
-minSdk = "21"
+minSdk = "23"
 
 # https://developer.android.com/ndk/downloads
 ndk = "28.2.13676358"

--- a/rsdroid-instrumented/build.gradle
+++ b/rsdroid-instrumented/build.gradle
@@ -42,6 +42,20 @@ android {
         targetCompatibility JavaVersion.VERSION_11
     }
 
+    // TODO: fix direct APK loading/compression
+    // In brief: we want an uncompressed .so, so we can mmap directly from the apk
+    // this saves copying the .so at install-time, and saves a duplicated copy
+    // Not well-documented. Possibly useful:
+    // https://developer.android.com/build/releases/past-releases/agp-4-2-0-release-notes?utm_source=chatgpt.com#dex-files-uncompressed-in-apks-when-minsdk-=-28-or-higher
+    // https://developer.android.com/reference/tools/gradle-api/8.3/null/com/android/build/api/dsl/JniLibsPackaging#getUseLegacyPackaging()
+    // https://developer.android.com/topic/performance/reduce-apk-size#extract-false
+    // https://developer.android.com/guide/topics/manifest/application-element#extractNativeLibs
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging = true
+        }
+    }
+
     kotlinOptions {
         jvmTarget = '11'
     }


### PR DESCRIPTION
required by androidx.sqlite 2.6.0

> Updated the library’s Android minSDK from API 21 to API 23.

https://developer.android.com/jetpack/androidx/releases/sqlite#2.6.0

* Unblocks https://github.com/ankidroid/Anki-Android-Backend/pull/575

----

`useLegacyPackaging` was required, otherwise android tests failed with

`dlopen failed: library "librsdroid.so" not found`