### PR TITLE
Ci caching fixes

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -155,6 +155,7 @@ jobs:
           key: ${{ runner.os }}-rust-debug-${{ hashFiles('Cargo.lock', 'anki/Cargo.lock', 'anki/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-rust-debug
+            ${{ runner.os }}-rust
 
       - name: Restore Rust Cache (Unix)
         id: rust-cache-unix
@@ -172,6 +173,7 @@ jobs:
           key: ${{ runner.os }}-rust-debug-${{ hashFiles('Cargo.lock', 'anki/Cargo.lock', 'anki/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-rust-debug
+            ${{ runner.os }}-rust
 
       - name: Setup N2
         run: bash ./anki/tools/install-n2

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -85,6 +85,7 @@ jobs:
           key: ${{ runner.os }}-rust-release-${{ hashFiles('Cargo.lock', 'anki/Cargo.lock', 'anki/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-rust-release
+            ${{ runner.os }}-rust
 
       - name: Setup N2
         run: ./anki/tools/install-n2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -126,6 +126,7 @@ jobs:
         key: ${{ runner.os }}-rust-debug-${{ hashFiles('Cargo.lock', 'anki/Cargo.lock', 'anki/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-rust-debug
+          ${{ runner.os }}-rust
 
     - name: Setup N2
       if: matrix.build-mode == 'manual'


### PR DESCRIPTION
1- we were not calculating our cache key with anki/Cargo.lock taken into account, but it should have been

--> add it to the hashFiles list for cache key creation, and just use one hashFiles, but with all hashed files specified in it

2- we were recalculating the cache key in save, in violation of "don't repeat yourself" coding standard, which is bad for all the standard reasons

--> label the cache restore steps with an id, and re-use the cache key on save via the output property from restore

3- we were not caching the same set of paths in release workflow save vs restore, so cache would never hit (https://github.com/actions/cache#cache-version)

--> use the same set of paths in all workflows between save and restore, via manual fix

4- we were isolating our debug and release build caches, and they are different but they are still helpful since release also builds debug, and lots of the rust compile time is utilities that are always debug (`toml`, `jaq`, `n2` etc)

--> allow debug and release to share caches via a new / last-chance secondary restore key


This was all discovered during perf tuning pass on #587 when I was puzzled by build-release cache restore failure when it should have been a hit.