### PR TITLE
perf(ci): also fallback from self-hosted runners if self-hosted are busy

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -27,9 +27,9 @@ jobs:
     outputs:
       runner: ${{ steps.determine-macos-runner.outputs.use-runner }}
     steps:
-      - name: Use self-hosted runner if online, otherwise public runner
+      - name: Use self-hosted runner if online and not busy, otherwise public runner
         id: determine-macos-runner
-        uses: mikehardy/runner-fallback-action@feat/orgsandents
+        uses: mikehardy/runner-fallback-action@extra-merges
         with:
           organization: "ankidroid"
           # 1- Choices are single labels, emitted array element 0 is used directly below
@@ -37,6 +37,7 @@ jobs:
           #    It is in format 'macos-*' to work with our label splitter below
           primary-runner: "macos-selfhosted"
           fallback-runner: "macos-26"
+          primaries-required: 1
           github-token: ${{ secrets.MIKE_HARDY_ORG_ADMIN_KEY }}
 
   # We want to generate our matrix dynamically

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -37,14 +37,15 @@ jobs:
     outputs:
       runner: ${{ steps.determine-macos-runner.outputs.use-runner }}
     steps:
-      - name: Use self-hosted runner if online, otherwise public runner
+      - name: Use self-hosted runner if online and not busy, otherwise public runner
         id: determine-macos-runner
-        uses: mikehardy/runner-fallback-action@feat/orgsandents
+        uses: mikehardy/runner-fallback-action@extra-merges
         with:
           organization: "ankidroid"
           # self-hosted runner label is configured in Tartelet app on runner host
           primary-runner: "macos-selfhosted"
           fallback-runner: "macos-26"
+          primaries-required: 1
           github-token: ${{ secrets.MIKE_HARDY_ORG_ADMIN_KEY }}
 
   build:


### PR DESCRIPTION
they are intended to augment public runner capacity not replace it

I can only run 2 at once and sometimes my machine is loaded so throughput will possibly be lower if my compute is online

With this extra feature throughput can potentially be greater, as it will use my compute first if available but then use public runners as my compute is occupied

This is the last optimization I can think of