### PR TITLE
fix(ci): use fallback runner if there is any sort of error

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -39,6 +39,9 @@ jobs:
           fallback-runner: "macos-26"
           primaries-required: 1
           fallback-on-error: true
+          # Actions secrets and Dependabot secrets are separate, and this is at org level::
+          # https://github.com/organizations/ankidroid/settings/secrets/dependabot
+          # https://github.com/organizations/ankidroid/settings/secrets/actions
           github-token: ${{ secrets.MIKE_HARDY_ORG_ADMIN_KEY }}
 
   # We want to generate our matrix dynamically

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -47,6 +47,9 @@ jobs:
           fallback-runner: "macos-26"
           primaries-required: 1
           fallback-on-error: true
+          # Actions secrets and Dependabot secrets are separate, and this is at org level::
+          # https://github.com/organizations/ankidroid/settings/secrets/dependabot
+          # https://github.com/organizations/ankidroid/settings/secrets/actions
           github-token: ${{ secrets.MIKE_HARDY_ORG_ADMIN_KEY }}
 
   build:


### PR DESCRIPTION
no reason to block CI if there is any sort of problem, self-hosted runners are purely a nice to have and should never block really

uses this commit from the PR I'm trying to get merged upstream:

https://github.com/jimmygchen/runner-fallback-action/pull/31/commits/b01652760b007b7ee68b15c4211fb2310d37c03a

but since there is no merge activity in that runner selection action, it's running off the PR branch on my fork 🤷 