### PR TITLE
fix(ci): runner determination needs to run serially

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -24,6 +24,9 @@ jobs:
   # We may have a self-hosted runner available for macOS. Use it if so.
   determine-macos-runner:
     runs-on: ubuntu-latest
+    concurrency:
+      group: runner-determination
+      cancel-in-progress: false
     outputs:
       runner: ${{ steps.determine-macos-runner.outputs.use-runner }}
     steps:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,6 +34,9 @@ jobs:
   # We may have a self-hosted runner available for macOS. Use it if so.
   determine-macos-runner:
     runs-on: ubuntu-latest
+    concurrency:
+      group: runner-determination
+      cancel-in-progress: false
     outputs:
       runner: ${{ steps.determine-macos-runner.outputs.use-runner }}
     steps:


### PR DESCRIPTION
otherwise two workflows triggered in parallel from the same event could both determine that self-hosted is "available" and ther are enough instances available, even though only one runner is available, because they both run the determination before the runner is occupied by the later jobs in the same workflow

- Fixes #600 

(...which only happened because I was manually / contemporaneously watching the underlying issue this solves cause unexpected behavior on the computer next to me and in workflow sequencing, and I killed the runner while it was in process...)