### PR TITLE
test(ci): wait for parallel runs to occupy runners before choosing

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -30,6 +30,10 @@ jobs:
     outputs:
       runner: ${{ steps.determine-macos-runner.outputs.use-runner }}
     steps:
+      - name: Wait for possible parallel workflow run job startup lag
+        # After runner choice, the job that will use it has unavoidable job startup lag
+        # Wait for that job start / runner state change before we choose the runner for this run
+        run: sleep 15
       - name: Use self-hosted runner if online and not busy, otherwise public runner
         id: determine-macos-runner
         uses: mikehardy/runner-fallback-action@v1

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -40,6 +40,10 @@ jobs:
     outputs:
       runner: ${{ steps.determine-macos-runner.outputs.use-runner }}
     steps:
+      - name: Wait for possible parallel workflow run job startup lag
+        # After runner choice, the job that will use it has unavoidable job startup lag
+        # Wait for that job start / runner state change before we choose the runner for this run
+        run: sleep 15
       - name: Use self-hosted runner if online and not busy, otherwise public runner
         id: determine-macos-runner
         uses: mikehardy/runner-fallback-action@v1


### PR DESCRIPTION

Hopefully the last tweak here to have a system that meets the stated goal:

workflows here should never error or queue waiting for a self-hosted runner, regardless of self-hosted runner state

If it's totally down, github hosted runners should be used
if it is up but occupied, no jobs should queue, github hosted runners should be used

Sounds simple but has some subtlety about it apparently