### PR TITLE
test(ci): quiet brew warnings if package is already installed

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -116,12 +116,12 @@ jobs:
 
       - name: Install Windows cross compiler
         run: |
-          brew install mingw-w64
+          brew install --quiet mingw-w64
           x86_64-w64-mingw32-gcc -v
 
       - name: Install Linux cross compiler
         run: |
-          brew install MaterializeInc/crosstools/x86_64-unknown-linux-gnu
+          brew install --quiet MaterializeInc/crosstools/x86_64-unknown-linux-gnu
           x86_64-unknown-linux-gnu-gcc -v
 
       - name: Setup N2


### PR DESCRIPTION

Just attempting to clean up the build summary, while I was in there paying attention

Unfortunately I cannot get rid of the "cache save failed" warning, for us that is an expected output when the cache primary key was a hit and it's a full match on scope / key / version between save/restore.

By default caches are immutable so the save fails in that case but they emit a warning you can't silence. There are workarounds to either have the key change every run or do a delete-prior-to-save if that helps your workload's caching behavior but I don't think our caches would benefit - changing key per run would cause LRU behavior to evict unrelated caches via quota impacts, and the pre-delete style only helps if your cache really does go stale under the same scope/key/version which ours does not I think. So I'll let it be.

<img width="1184" height="642" alt="image" src="https://github.com/user-attachments/assets/f94928ec-20c1-41ef-8395-c77bceda3927" />
