### PR TITLE
use local maven repo since linking to the .aar directly makes things not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ var RELEASE=1 defined, to build a faster version.
 
 ## Modify AnkiDroid to use built library
 
+Install the .aar to a local maven repo with `./gradlew :rsdroid:publishReleasePublicationToMavenRepository`
+
 Now open the AnkiDroid project in AndroidStudio. To tell gradle to load the
 compiled .aar and .jar files from disk, edit `local.properties`
 in the AnkiDroid repo, and add the following line:

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -78,6 +78,22 @@ static def getBackendGitCommitHash() {
     "git rev-parse HEAD".execute().text.trim()
 }
 
+publishing {
+    publications {
+        release(MavenPublication) {
+            groupId = 'io.github.david-allison'
+            artifactId = 'rsdroid'
+            version = '1.0.0'
+            artifact("$buildDir/outputs/aar/rsdroid-release.aar")
+        }
+    }
+    repositories {
+        maven {
+            url = uri("${rootProject.buildDir}/localMaven")
+        }
+    }
+}
+
 android {
     namespace = 'net.ankiweb.rsdroid'
     compileSdk = libs.versions.compileSdk.get().toInteger()
@@ -186,6 +202,14 @@ tasks.register('installGitHook', Copy) {
 }
 // to run manually: `./gradlew installGitHook`
 tasks.named('preBuild').configure { dependsOn('installGitHook') }
+
+// don't require signing when publishing to a local maven folder
+tasks.withType(Sign) {
+    onlyIf {
+        def url = project.publishing.repositories.find { it.name == 'maven' }?.url?.toString()
+        !url?.contains('localMaven')
+    }
+}
 
 mavenPublishing {
     // Use https://central.sonatype.com/account with david-allison's GitHub login, not Google

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,11 @@
+dependencyResolutionManagement {
+    repositories {
+        maven {
+            url = uri("${rootProject.projectDir}/build/localMaven")
+        }
+    }
+}
+
 pluginManagement {
     repositories {
         google()


### PR DESCRIPTION
closes #671

disclaimer: I have no idea what I am doing. I have managed to get this all working but I am unsure if this is the _correct_ way to do things.

I don't know how things are published normally, but it is configured such that `publishReleasePublicationToMavenRepository` will work fine where `publishReleasePublicationToMavenCentral` requires some sort of credentials I do not have. so I am assuming is is correct.