### PR TITLE
build(deps): adopt anki 26.05

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,7 @@ dependencies = [
  "reqwest",
  "rusqlite",
  "rustls-pemfile",
+ "same-file",
  "scopeguard",
  "serde",
  "serde-aux",
@@ -197,6 +198,7 @@ name = "anki_io"
 version = "0.0.0"
 dependencies = [
  "camino",
+ "rand 0.9.4",
  "snafu",
  "tempfile",
 ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison
-VERSION_NAME=0.1.65-anki26.05b1
+VERSION_NAME=0.1.66-anki26.05
 
 POM_INCEPTION_YEAR=2020
 


### PR DESCRIPTION
now `0.1.66-anki26.05`

https://github.com/ankitects/anki/releases/26.05

hash: e64c6b1aee3e8d668fb8bbe084beada8e070d985

```
cd anki
git fetch origin
git checkout 26.05 --recurse-submodules
cd ../
./build.sh
./check-rust.sh
```

* https://github.com/ankidroid/Anki-Android/issues/21016
* Fixes #698