### PR TITLE
feat(class-loader): handle backend requests from multiple classloaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,24 @@ the repository.
 shows up in
 https://repo1.maven.org/maven2/io/github/david-allison/anki-android-backend/
 
+## test library copies
+
+> [!WARNING] 
+> The original library and up to 5 copies of the test library are persisted on disk
+> **per version of the test library**. It is the responsibility of the 
+> calling project to warn about these files. They are not automatically 
+> cleaned up.
+
+`rsdroid-testing` extracts the backend library to `java.io.tmpdir`.
+Copies are kept alongside the original:
+
+```
+librsdroid-<sha1>.dylib      the extracted library
+librsdroid-<sha1>-1.dylib    a copy of the library, created if a second classloader requires it 
+```
+
+See [ClassLoaderLibraryCopy.kt](rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/ClassLoaderLibraryCopy.kt) for details.
+
 ## Architecture
 
 See [ARCHITECTURE.md](./docs/ARCHITECTURE.md)

--- a/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/ClassLoaderLibraryCopy.kt
+++ b/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/ClassLoaderLibraryCopy.kt
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Workaround for each JVM classloader requiring a distinct path to a library file: each classloader
+ * is assigned a separate on-disk copy of a library if it requires it.
+ *
+ * @see loadCopyForCurrentClassLoader
+ */
+package net.ankiweb.rsdroid.testing
+
+import java.io.File
+
+/**
+ * The maximum number of copies of the library on disk (excluding the original)
+ *
+ * Each copy allocates ~60MB of space.
+ * This limit may need to be increased in future if there are more than 6 classloaders in a JVM
+ * which require the library.
+ *
+ * [loadCopyForCurrentClassLoader] will throw [IllegalStateException] if this limit is breached.
+ */
+internal var maxCopies: Int
+    get() = System.getProperty("net.ankiweb.rsdroid.testing.maxCopies")?.toIntOrNull()?.coerceAtLeast(1) ?: 5
+    set(value) {
+        require(value >= 1) { "at least one copy of the library is needed" }
+        System.setProperty("net.ankiweb.rsdroid.testing.maxCopies", value.toString())
+    }
+
+/** A cursor pointing to the next 'likely-available' library. */
+private var nextCopy: Int
+    // Use a system property to share it between classloaders
+    get() = System.getProperty("net.ankiweb.rsdroid.testing.nextCopy")?.toIntOrNull() ?: 1
+    set(value) {
+        System.setProperty("net.ankiweb.rsdroid.testing.nextCopy", value.toString())
+    }
+
+/** Whether Java refused to load a library because another classloader owns the file */
+internal val UnsatisfiedLinkError.isOwnedByAnotherClassLoader: Boolean
+    get() = message?.contains("already loaded in another classloader") == true
+
+/**
+ * Loads a copy of the library at [path] which no other classloader in this process owns.
+ *
+ * Up to [maxCopies] copies are numbered and reused.
+ *
+ * Copies are left behind for later runs: [path] contains a checksum of the library, so a copy of it
+ * is only ever reused for the same content.
+ *
+ * This method is responsible for calling [Runtime.load].
+ *
+ * @param path a library file which another classloader owns
+ * @throws UnsatisfiedLinkError no copy of the library could be loaded
+ * @throws IllegalStateException [maxCopies] classloaders already hold a copy
+ */
+internal fun loadCopyForCurrentClassLoader(path: String) {
+    val library = File(path)
+    val loaded = library.copiesToTry().firstOrNull { copy -> copy.loadIfUnowned() }
+    checkNotNull(loaded) {
+        "More than $maxCopies classloaders require a distinct copy of the library. " +
+            "See RustBackendLoader.maxOnDiskLibraryCopies for tradeoffs."
+    }
+    // the next classloader starts after the copy this one now owns
+    nextCopy = loaded.number % maxCopies + 1
+}
+
+/** A numbered copy of a library, which at most one classloader may own */
+private class LibraryCopy(
+    val number: Int,
+    private val file: File,
+) {
+    /**
+     * Loads this copy into the classloader which loaded this class.
+     *
+     * @return whether it was loaded: `false` if another classloader owns it
+     * @throws UnsatisfiedLinkError the copy could not be loaded
+     */
+    fun loadIfUnowned(): Boolean =
+        try {
+            Runtime.getRuntime().load(file.absolutePath)
+            true
+        } catch (e: UnsatisfiedLinkError) {
+            if (!e.isOwnedByAnotherClassLoader) {
+                throw e
+            }
+            false
+        }
+}
+
+/**
+ * The copies of this library, in the order to try them.
+ *
+ * [nextCopy] comes first: a classloader owns at most one copy, so the copy after the one which last
+ * worked is normally free, making this a single load. The rest follow, wrapping around, as a copy is
+ * freed when its classloader is collected - Robolectric evicts sandboxes as a suite runs.
+ *
+ * The original (number 0) comes last: the caller found it to be owned, but its owner may be
+ * collected during the sweep, or by the GC in [loadCopyFreedByGc].
+ *
+ * The sequence is lazy, so a copy is only made once every copy before it is found to be owned.
+ */
+private fun File.copiesToTry(): Sequence<LibraryCopy> {
+    val copies = maxCopies
+    val first = nextCopy.coerceIn(1, copies)
+    return ((first..copies) + (1..<first) + 0)
+        .asSequence()
+        .map { number -> LibraryCopy(number, numberedCopy(number)) }
+}
+
+/**
+ * @return copy number [index] of this library, creating it if required. Copy 0 is the original.
+ */
+private fun File.numberedCopy(index: Int): File {
+    if (index == 0) return this
+    // the extension is retained: `Runtime.load` requires it on Windows
+    val copy = File(parentFile, "$nameWithoutExtension-$index.$extension")
+    if (!copy.exists()) {
+        copyAtomicallyTo(copy)
+    }
+    return copy
+}

--- a/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/ClassLoaderLibraryCopy.kt
+++ b/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/ClassLoaderLibraryCopy.kt
@@ -54,13 +54,36 @@ internal val UnsatisfiedLinkError.isOwnedByAnotherClassLoader: Boolean
  */
 internal fun loadCopyForCurrentClassLoader(path: String) {
     val library = File(path)
-    val loaded = library.copiesToTry().firstOrNull { copy -> copy.loadIfUnowned() }
+    val loaded = library.loadUnownedCopy() ?: library.loadCopyFreedByGc()
     checkNotNull(loaded) {
         "More than $maxCopies classloaders require a distinct copy of the library. " +
             "See RustBackendLoader.maxOnDiskLibraryCopies for tradeoffs."
     }
     // the next classloader starts after the copy this one now owns
     nextCopy = loaded.number % maxCopies + 1
+}
+
+/**
+ * Loads the first copy of this library which no classloader owns.
+ *
+ * @return the loaded copy, or `null` if every copy is owned
+ */
+private fun File.loadUnownedCopy(): LibraryCopy? = copiesToTry().firstOrNull { copy -> copy.loadIfUnowned() }
+
+/**
+ * [loadUnownedCopy], after asking the JVM to collect discarded classloaders.
+ *
+ * @return the loaded copy, or `null` if every copy remained owned
+ */
+private fun File.loadCopyFreedByGc(): LibraryCopy? {
+    repeat(10) {
+        // GC is a hint - try a few times
+        System.gc()
+        // The JVM closes the collected classloader's libraries asynchronously
+        Thread.sleep(50)
+        loadUnownedCopy()?.let { return it }
+    }
+    return null
 }
 
 /** A numbered copy of a library, which at most one classloader may own */

--- a/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/FileUtils.kt
+++ b/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/FileUtils.kt
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package net.ankiweb.rsdroid.testing
+
+import java.io.File
+import java.io.IOException
+
+/**
+ * Copies this file to [destination] [atomically][createAtomically].
+ *
+ * @throws IOException [destination] could neither be created nor found
+ */
+internal fun File.copyAtomicallyTo(destination: File) {
+    destination.createAtomically { temporary -> copyTo(temporary, overwrite = true) }
+}
+
+/**
+ * Creates this file in an atomic manner.
+ *
+ * If another process creates this file first, their file is left in place.
+ *
+ * @param write populates the temporary file which becomes this file
+ * @throws IOException this file could neither be created nor found
+ */
+internal fun File.createAtomically(write: (File) -> Unit) {
+    val temporary = File.createTempFile("$nameWithoutExtension-", ".tmp", parentFile)
+    try {
+        write(temporary)
+        // this fails on Windows if another process created this file first
+        if (!temporary.renameTo(this) && !exists()) {
+            throw IOException("failed to move $temporary to $this")
+        }
+    } finally {
+        temporary.delete()
+    }
+}

--- a/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/RustBackendLoader.kt
+++ b/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/RustBackendLoader.kt
@@ -32,6 +32,20 @@ object RustBackendLoader {
     var PRINT_DEBUG = false
 
     /**
+     * How many copies of the backend library may be kept on disk. Each classloader using the
+     * backend uses a distinct copy (~60MB as-of writing).
+     *
+     * Set this before [ensureSetup] if a suite uses more classloaders than the default allows. It
+     * applies to the whole process, not only to the classloader which sets it.
+     */
+    @JvmStatic
+    var maxOnDiskLibraryCopies: Int
+        get() = maxCopies
+        set(value) {
+            maxCopies = value
+        }
+
+    /**
      * Allows unit testing rsdroid under Robolectric <br></br>
      * Loads (via [Runtime.load]) a librsdroid.so alternative compiled for the current operating system.<br></br><br></br>
      *
@@ -94,7 +108,7 @@ object RustBackendLoader {
      * (eg some do not use Robolectric's classloader at all, and other tests like BindingAndroidTest
      * will use multiple classloader instances due to the use of @Config). This means this code
      * is not guaranteed to execute only once, and after the first invocation, an "already loaded"
-     * error will be thrown by Java, which we have to swallow.
+     * error will be thrown by Java, which we handle by loading a private copy of the library.
      */
     private fun loadPath(path: String) {
         try {
@@ -105,11 +119,15 @@ object RustBackendLoader {
                     FileNotFoundException("Extracted file was not found. Maybe the temp folder was deleted. Please try again: '$path'")
                 throw RuntimeException(exception)
             }
-            if (e.message == null || !e.message!!.contains("already loaded in another classloader")) {
+            if (!e.isOwnedByAnotherClassLoader) {
                 throw e
-            } else {
-                // native library loaded by a different classloader in the same process
             }
+            // A JVM allows one classloader to own a library file, and a native method only binds to
+            // a library loaded by its own class's classloader.
+
+            // Each Robolectric sandbox has a separate classloader, so we can use a separate
+            // library path to fix 'already loaded in another classloader'
+            loadCopyForCurrentClassLoader(path)
         }
     }
 
@@ -148,18 +166,16 @@ object RustBackendLoader {
             }
         val expectedFile = File(System.getProperty("java.io.tmpdir"), "$fileName-$checksum$extension")
         if (!expectedFile.exists()) {
-            val tempFile = File.createTempFile(fileName, extension)
-            tempFile.outputStream().use { outStream ->
-                withStream(fullFilename) { inStream ->
-                    var bytesRead: Int
-                    while (inStream.read(buffer).also { bytesRead = it } != -1) {
-                        outStream.write(buffer, 0, bytesRead)
+            expectedFile.createAtomically { temporary ->
+                temporary.outputStream().use { outStream ->
+                    withStream(fullFilename) { inStream ->
+                        var bytesRead: Int
+                        while (inStream.read(buffer).also { bytesRead = it } != -1) {
+                            outStream.write(buffer, 0, bytesRead)
+                        }
                     }
                 }
-                outStream.flush()
-                outStream.close()
             }
-            tempFile.renameTo(expectedFile)
         }
         FILENAME_TO_PATH_CACHE[fullFilename] = expectedFile.path
         return expectedFile.absolutePath


### PR DESCRIPTION
> [!NOTE] 
> Assisted-by: Claude Opus 5 - implementation

> [!NOTE]
> (cherry picked from commit cde8375625f0dc9e5e287aeedac992ff8c3736de) - the change should not have gone to `main` without review.

Each Classloader needs a separate on-disk file or a `UnsatisfiedLinkError` is thrown.

To fix this:

* Persist a collection of 10 files on-disk
  * We do this as we cannot guarantee file deletion on Windows

```
librsdroid-<sha1>.dylib      the extracted library
librsdroid-<sha1>-1.dylib    a copy of the library, created if a second classloader requires it
```

* Walk through the libraries using a cursor and load an unused one
* Devise a script for Anki-Android to warn developers if there are too many stale copies on disk (each is 60MB)

----

* Fixes most of the following, a merge of an updated backend library will resolve it ankidroid/Anki-Android#14796


