### PR TITLE
build: read FSRS_VERSION from anki/Cargo.lock

### DIFF
--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 import java.util.zip.ZipFile
-import org.gradle.internal.os.OperatingSystem
 
 apply plugin: 'com.android.library' // required for aar generation to link to from AnkiDroid
 apply plugin: "kotlin-android"
@@ -22,43 +21,15 @@ def getAnkiCommitHash = { ->
 }
 
 def getFsrsVersion = { ->
-    // Ensure "jaq" cargo module is installed before we try to use it
-    def crateInfo = providers.exec {
-        commandLine "cargo", "install", "--list"
-    }.standardOutput.asText.get()
-    if (!crateInfo.contains("jaq v2.1.0")) {
-        println("jaq rust crate not installed, needed to fetch FSRS version. Installing...")
-        def jaqInstallProcess = new ProcessBuilder()
-                .command("cargo", "install", "jaq@2.1.0")
-                .redirectErrorStream(true)
-                .start()
-        def jaqOutput = new BufferedReader(new InputStreamReader(jaqInstallProcess.getInputStream()))
-        while (jaqInstallProcess.isAlive()) {
-            def jaqOutputLine = jaqOutput.readLine()
-            if (jaqOutputLine != null) {
-                System.out.println(jaqOutput.readLine())
-            }
-        }
-        jaqInstallProcess.waitFor()
+    // the fsrs version is pinned in anki/Cargo.lock:
+    //  name = "fsrs"
+    //  version = "A.B.C"
+    def lockText = new File("${project.rootDir}", "anki/Cargo.lock").getText("UTF-8")
+    def matcher = lockText =~ /(?m)^name = "fsrs"\r?\nversion = "([^"]+)"/
+    if (!matcher.find()) {
+        throw new GradleException("Could not find the fsrs version in anki/Cargo.lock")
     }
-    def verStdin = providers.exec {
-         commandLine "cargo", "metadata", "--locked", "--format-version=1", "--manifest-path=" + new File("${project.rootDir}", "anki/Cargo.toml")
-    }.standardOutput.asBytes.get()
-
-    def verArgs = OperatingSystem.current() == OperatingSystem.WINDOWS ?
-            ".packages[] | select(.name==\\\"fsrs\\\") | .version" :
-            ".packages[] | select(.name==\"fsrs\") | .version"
-
-    // use "jaq" cargo module installed during rust build: self-contained + cross-platform
-    // if we use `jq` we are dependent on local system utility installation status
-    def getFsrsVersionProcess = new ProcessBuilder().command("jaq", verArgs).start()
-    def getFsrsVersionStdin = getFsrsVersionProcess.getOutputStream()
-    getFsrsVersionStdin.write(verStdin)
-    getFsrsVersionStdin.flush()
-    getFsrsVersionStdin.close()
-
-    def verStdout = new String(getFsrsVersionProcess.getInputStream().readAllBytes())
-    def version = verStdout.trim().replace("\"", "")
+    def version = matcher.group(1)
     println("FSRS version: ${version}")
     return version
 }

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -21,13 +21,14 @@ def getAnkiCommitHash = { ->
 }
 
 def getFsrsVersion = { ->
-    // the fsrs version is pinned in anki/Cargo.lock:
+    // the compiled fsrs version is resolved by the root Cargo.lock, not anki/Cargo.lock:
+    // rslib-bridge consumes anki as a path dependency, whose lockfile cargo ignores
     //  name = "fsrs"
     //  version = "A.B.C"
-    def lockText = new File("${project.rootDir}", "anki/Cargo.lock").getText("UTF-8")
+    def lockText = rootProject.file("Cargo.lock").getText("UTF-8")
     def matcher = lockText =~ /(?m)^name = "fsrs"\r?\nversion = "([^"]+)"/
     if (!matcher.find()) {
-        throw new GradleException("Could not find the fsrs version in anki/Cargo.lock")
+        throw new GradleException("Could not find the fsrs version in Cargo.lock")
     }
     def version = matcher.group(1)
     println("FSRS version: ${version}")


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

* this removes a reference to `cargo`, which can cause a Gradle sync to fail if `cargo` is not on PATH.

Also prep for moving to a `java-library`:
* Issue #674

