### PR TITLE
fix(scripts): better error for missing anki submodule

### DIFF
--- a/check-rust.sh
+++ b/check-rust.sh
@@ -5,5 +5,12 @@ set -e
 # Non-zero exit on warnings
 export RUSTFLAGS="-Dwarnings"
 
+if [ ! -d anki/cargo/format ]; then
+    echo "error: 'anki/cargo/format' not found: the anki submodule is not checked out." >&2
+    echo "This is required after a fresh clone or in a new git worktree. To fix, run:" >&2
+    echo "    git submodule update --init --recursive" >&2
+    exit 1
+fi
+
 rustup component add clippy && cargo clippy
 (cd anki/cargo/format && cargo fmt --check --all --manifest-path ../../../Cargo.toml)

--- a/format-rust.sh
+++ b/format-rust.sh
@@ -2,4 +2,11 @@
 
 set -e
 
+if [ ! -d anki/cargo/format ]; then
+    echo "error: 'anki/cargo/format' not found: the anki submodule is not checked out." >&2
+    echo "This is required after a fresh clone or in a new git worktree. To fix, run:" >&2
+    echo "    git submodule update --init --recursive" >&2
+    exit 1
+fi
+
 (cd anki/cargo/format && cargo fmt --all --manifest-path ../../../Cargo.toml)


### PR DESCRIPTION
```diff
- cd: anki/cargo/format: No such file or directory
+ error: 'anki/cargo/format' not found: the anki submodule is not checked out.
+ This is required after a fresh clone or in a new git worktree. To fix, run:
+     git submodule update --init --recursive
```

Assisted-by: Claude Fable 5