### PR TITLE
build(ci): run lint on the quick CI check; remove from CodeQL

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -261,7 +261,7 @@ jobs:
         run: ./check-rust.bat
 
       - name: Run tests (Unit)
-        run: ./gradlew test rsdroid:lint --daemon
+        run: ./gradlew test rsdroid:lint ktlintCheck --daemon
 
       - name: Run tests (Emulator)
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -183,7 +183,10 @@ jobs:
       if: matrix.build-mode == 'manual'
       run: |
         cargo run -p build_rust
-        ./gradlew build
+        # 'build test -x check': compile everything and run unit tests, but skip
+        # the other 'check' tasks (ktlint, Android Lint) which normal CI covers
+        # TODO: Only compile tests for CodeQL, don't run them
+        ./gradlew build test -x check
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
CodeQL ran this instead, which was unusual

* https://github.com/ankidroid/Anki-Android-Backend/pull/719

Assisted-by: Claude Fable 5