### PR TITLE
build(deps): remove `androidx.appcompat` & `fileTree`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,8 @@ minSdk = "23"
 # https://developer.android.com/ndk/downloads
 ndk = "29.0.14206865"
 
+# https://developer.android.com/jetpack/androidx/releases/annotation
+androidxAnnotation = "1.9.1"
 # https://developer.android.com/jetpack/androidx/releases/appcompat
 androidxAppCompat = "1.8.0"
 # https://developer.android.com/jetpack/androidx/releases/core
@@ -36,6 +38,7 @@ ktlint = '1.5.0'
 ktlintGradlePlugin = "14.2.0"
 
 [libraries]
+androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidxAnnotation" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidxAppCompat" }
 androidx-core = { module = "androidx.test:core", version.ref = "androidxCore" }
 androidx-sqlite-framework = { module = "androidx.sqlite:sqlite-framework", version.ref = "androidxSqlite" }

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -126,6 +126,7 @@ dependencies {
     // Protobuf is part of the ABI, so include it as a compile/api dependency.
     api libs.protobuf.kotlin.lite
 
+    implementation libs.androidx.annotation
     implementation libs.androidx.sqlite.ktx
     implementation libs.androidx.sqlite.framework
     implementation libs.jakewharton.timber

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -121,7 +121,6 @@ afterEvaluate {
 }
 
 dependencies {
-    implementation fileTree(dir: "libs", include: ["*.jar", '*.so'])
     // Protobuf is part of the ABI, so include it as a compile/api dependency.
     api libs.protobuf.kotlin.lite
 

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -122,7 +122,6 @@ afterEvaluate {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar", '*.so'])
-    implementation libs.androidx.appcompat
     // Protobuf is part of the ABI, so include it as a compile/api dependency.
     api libs.protobuf.kotlin.lite
 


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

* Part of #674

----

* removing `appcompat` is necessary to go to `java-library`
* `fileTree` was a cleanup in my `java-library` branch, which was simple to pull into this PR