### PR TITLE
build(deps): migrate Timber -> SLF4J

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,9 @@ kotlin = '2.4.10'
 # https://github.com/protocolbuffers/protobuf/releases
 protobuf = "4.36.1"
 robolectric = "4.16.1"
+# https://www.slf4j.org/news.html
+# must stay on 1.7.x for AnkiDroid's slf4j-timber bridge: see Slf4jBindingTest
+slf4j = "1.7.36"
 timber = "5.0.1"
 ktlint = '1.5.0'
 ktlintGradlePlugin = "14.2.0"
@@ -46,6 +49,7 @@ androidx-sqlite-ktx = { module = "androidx.sqlite:sqlite-ktx", version.ref = "an
 commons-exec = { module = "org.apache.commons:commons-exec", version.ref = "commonsExec" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 protobuf-kotlin-lite = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "protobuf" }
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 
 # testing libs
 androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestJunit" }

--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -127,7 +127,7 @@ dependencies {
     implementation libs.androidx.annotation
     implementation libs.androidx.sqlite.ktx
     implementation libs.androidx.sqlite.framework
-    implementation libs.jakewharton.timber
+    implementation libs.slf4j.api
 
     testImplementation libs.junit.jupiter
     testImplementation libs.robolectric

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/Backend.kt
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/Backend.kt
@@ -30,12 +30,14 @@ import net.ankiweb.rsdroid.database.SQLHandler
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
-import timber.log.Timber
+import org.slf4j.LoggerFactory
 import java.io.Closeable
 import java.io.File
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
+
+private val logger = LoggerFactory.getLogger(Backend::class.java)
 
 open class Backend(
     langs: Iterable<String> = listOf("en"),
@@ -84,7 +86,7 @@ open class Backend(
      */
     init {
         checkMainThreadOp()
-        Timber.d("Opening rust backend with lang=$langs")
+        logger.debug("Opening rust backend with lang={}", langs)
         val input =
             BackendInit
                 .newBuilder()
@@ -100,7 +102,7 @@ open class Backend(
      */
     override fun close() {
         checkMainThreadOp()
-        Timber.d("Closing rust backend")
+        logger.debug("Closing rust backend")
         backendLock.write {
             NativeMethods.closeBackend(backendPointer!!)
             backendPointer = null
@@ -249,9 +251,9 @@ open class Backend(
                         }
                         true
                     }.first()
-            Timber.w("Op on UI thread: %s", firstElem)
+            logger.warn("Op on UI thread: {}", firstElem)
             sql?.let {
-                Timber.w("%s", sql)
+                logger.warn("{}", sql)
             }
         }
     }

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/database/AnkiDatabaseCursor.kt
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/database/AnkiDatabaseCursor.kt
@@ -22,7 +22,9 @@ import android.database.Cursor
 import android.database.DataSetObserver
 import android.net.Uri
 import android.os.Bundle
-import timber.log.Timber
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger(AnkiDatabaseCursor::class.java)
 
 /**
  * Base class for all database cursors, abstracting database methods to a common interface
@@ -80,7 +82,7 @@ abstract class AnkiDatabaseCursor : Cursor {
 
     @Deprecated("Deprecated in Java")
     override fun deactivate() {
-        Timber.w("deactivate - not implemented - throwing")
+        logger.warn("deactivate - not implemented - throwing")
         throw NotImplementedException()
     }
 
@@ -91,7 +93,7 @@ abstract class AnkiDatabaseCursor : Cursor {
 
     @Deprecated("Deprecated in Java")
     override fun requery(): Boolean {
-        Timber.w("requery - not implemented - throwing")
+        logger.warn("requery - not implemented - throwing")
         throw NotImplementedException()
     }
 
@@ -108,19 +110,19 @@ abstract class AnkiDatabaseCursor : Cursor {
     abstract override fun moveToPosition(nextPositionGlobal: Int): Boolean
 
     override fun registerContentObserver(observer: ContentObserver) {
-        Timber.w("Not implemented: registerContentObserver - shouldn't matter unless requery() is called")
+        logger.warn("Not implemented: registerContentObserver - shouldn't matter unless requery() is called")
     }
 
     override fun unregisterContentObserver(observer: ContentObserver) {
-        Timber.w("Not implemented: unregisterContentObserver - shouldn't matter unless requery() is called")
+        logger.warn("Not implemented: unregisterContentObserver - shouldn't matter unless requery() is called")
     }
 
     override fun registerDataSetObserver(observer: DataSetObserver) {
-        Timber.w("Not implemented: registerDataSetObserver - shouldn't matter unless requery() is called")
+        logger.warn("Not implemented: registerDataSetObserver - shouldn't matter unless requery() is called")
     }
 
     override fun unregisterDataSetObserver(observer: DataSetObserver) {
-        Timber.w("Not implemented: unregisterDataSetObserver - shouldn't matter unless requery() is called")
+        logger.warn("Not implemented: unregisterDataSetObserver - shouldn't matter unless requery() is called")
     }
 
     override fun isLast(): Boolean = position == lastPosition

--- a/rsdroid/src/test/java/net/ankiweb/Slf4jBindingTest.kt
+++ b/rsdroid/src/test/java/net/ankiweb/Slf4jBindingTest.kt
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package net.ankiweb
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.slf4j.LoggerFactory
+import org.slf4j.impl.TestBindingLoggerFactory
+
+/**
+ * AnkiDroid uses com.arcao:slf4j-timber which SLF4J ignores
+ *
+ * If this test fails after a dependency bump: keep slf4j-api on 1.7.x.
+ */
+class Slf4jBindingTest {
+    @Test
+    fun `slf4j API uses v1 Style Bindings`() {
+        assertEquals(
+            "slf4j-api no longer binds via StaticLoggerBinder (bumped to 2.x?). " +
+                "This silently breaks slf4j-timber",
+            TestBindingLoggerFactory::class.java,
+            LoggerFactory.getILoggerFactory().javaClass,
+        )
+    }
+}

--- a/rsdroid/src/test/java/org/slf4j/impl/StaticLoggerBinder.kt
+++ b/rsdroid/src/test/java/org/slf4j/impl/StaticLoggerBinder.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package org.slf4j.impl
+
+import org.slf4j.ILoggerFactory
+import org.slf4j.Logger
+import org.slf4j.helpers.NOPLogger
+
+/**
+ * A minimal SLF4J 1.7-style binding
+ *
+ * This serves two purposes:
+ * * silences logs in unit tests
+ * * Allows verification that 1.7-style bindings are used
+ */
+@Suppress("unused") // fields/methods are loaded by slf4j-api
+class StaticLoggerBinder private constructor() {
+    val loggerFactory: ILoggerFactory = TestBindingLoggerFactory()
+
+    fun getLoggerFactoryClassStr(): String = TestBindingLoggerFactory::class.java.name
+
+    companion object {
+        private val SINGLETON = StaticLoggerBinder()
+
+        @JvmStatic
+        fun getSingleton(): StaticLoggerBinder = SINGLETON
+
+        // read via a static field reference by slf4j-api's version sanity check
+        const val REQUESTED_API_VERSION: String = "1.7.36"
+    }
+}
+
+/** Discards all log output like slf4j-nop, but with a distinct type tests can assert on */
+class TestBindingLoggerFactory : ILoggerFactory {
+    override fun getLogger(name: String): Logger = NOPLogger.NOP_LOGGER
+}


### PR DESCRIPTION
* Part of #674

`slf4j-api` is pure JVM, so can be used in a `java-library`.

AnkiDroid uses com.arcao:slf4j-timber, so app log output is unchanged.

slf4j-api must stay on 1.7.x until AnkiDroid moves to a ServiceLoader-based provider (current unplanned).

Assisted-by: Claude Fable 5