### PR TITLE
backend: reduce Android dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,8 +15,6 @@ androidxCore = "1.7.0"
 # https://developer.android.com/jetpack/androidx/releases/sqlite
 androidxSqlite = "2.7.0"
 androidxTestJunit = "1.3.0"
-# https://commons.apache.org/proper/commons-exec/changes.html
-commonsExec = "1.6.0"
 espresso = "3.7.0"
 # AGP is included in Android Studio and changelogs are not well maintained/at a stable URL
 # Open https://developer.android.com/build/releases/gradle-plugin#patch-releases
@@ -46,7 +44,6 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-core = { module = "androidx.test:core", version.ref = "androidxCore" }
 androidx-sqlite-framework = { module = "androidx.sqlite:sqlite-framework", version.ref = "androidxSqlite" }
 androidx-sqlite-ktx = { module = "androidx.sqlite:sqlite-ktx", version.ref = "androidxSqlite" }
-commons-exec = { module = "org.apache.commons:commons-exec", version.ref = "commonsExec" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 protobuf-kotlin-lite = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "protobuf" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }

--- a/rsdroid-testing/build.gradle
+++ b/rsdroid-testing/build.gradle
@@ -28,9 +28,6 @@ plugins {
 apply from: "$rootDir/build-rust.gradle"
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    // obtaining the OS
-    implementation libs.commons.exec
     implementation libs.kotlin.stdlib.jdk8
 }
 

--- a/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/RustBackendLoader.kt
+++ b/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/RustBackendLoader.kt
@@ -15,12 +15,12 @@
  */
 package net.ankiweb.rsdroid.testing
 
-import org.apache.commons.exec.OS
 import java.io.*
 import java.lang.IllegalStateException
 import java.lang.RuntimeException
 import java.security.MessageDigest
 import java.util.HashMap
+import java.util.Locale
 import kotlin.Throws
 
 /**
@@ -51,15 +51,14 @@ object RustBackendLoader {
         }
         // This should help diagnose some issues,
         print("loading rsdroid-testing for: " + System.getProperty("os.name"))
-        if (OS.isFamilyWindows()) {
-            load("rsdroid", ".dll")
-        } else if (OS.isFamilyMac()) {
-            load("librsdroid", ".dylib")
-        } else if (OS.isFamilyUnix()) {
-            load("librsdroid", ".so")
-        } else {
-            val osName = System.getProperty("os.name")
-            throw IllegalStateException(String.format("Could not determine OS Type for: '%s'", osName))
+        // ':' is also macOS's path separator, so Mac is tested first
+        val osName = System.getProperty("os.name").lowercase(Locale.ROOT)
+        when {
+            osName.startsWith("windows") -> load("rsdroid", ".dll")
+            osName.startsWith("mac") -> load("librsdroid", ".dylib")
+            // pathSeparator == ":" is a commons-exec influenced check
+            File.pathSeparator == ":" -> load("librsdroid", ".so")
+            else -> throw IllegalStateException(String.format("Could not determine OS Type for: '%s'", osName))
         }
         hasSetUp = true
     }

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/Backend.kt
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/Backend.kt
@@ -15,7 +15,6 @@
  */
 package net.ankiweb.rsdroid
 
-import android.os.Looper
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import anki.ankidroid.DbResponse
@@ -68,7 +67,6 @@ open class Backend(
                     collectionPath.replace(".anki2", ".media.db"),
                 )
             }
-        checkMainThreadOp()
         openCollection(collectionPath, mediaFolder, mediaDb)
     }
 
@@ -85,7 +83,6 @@ open class Backend(
      * Open a backend instance, loading the shared library if not already loaded.
      */
     init {
-        checkMainThreadOp()
         logger.debug("Opening rust backend with lang={}", langs)
         val input =
             BackendInit
@@ -101,7 +98,6 @@ open class Backend(
      * Close the backend, and any open collection. This object can not be used after this.
      */
     override fun close() {
-        checkMainThreadOp()
         logger.debug("Closing rust backend")
         backendLock.write {
             NativeMethods.closeBackend(backendPointer!!)
@@ -139,12 +135,10 @@ open class Backend(
         service: Int,
         method: Int,
         input: ByteArray,
-    ): ByteArray {
-        checkMainThreadOp()
-        return withBackend {
+    ): ByteArray =
+        withBackend {
             unpackResult(NativeMethods.runMethodRaw(it, service, method, input))
         }
-    }
 
     /**
      * Run the provided closure with access to the backend.
@@ -178,7 +172,6 @@ open class Backend(
         sql: String,
         bindArgs: Array<Any?>,
     ): JSONArray {
-        checkMainThreadSQL(sql)
         val output = runDbCommand(dbRequestJson(sql, bindArgs)).toStringUtf8()
         return JSONArray(output)
     }
@@ -186,27 +179,18 @@ open class Backend(
     override fun insertForId(
         sql: String,
         bindArgs: Array<Any?>?,
-    ): Long {
-        checkMainThreadSQL(sql)
-        return super.insertForId(dbRequestJson(sql, bindArgs ?: emptyArray()))
-    }
+    ): Long = super.insertForId(dbRequestJson(sql, bindArgs ?: emptyArray()))
 
     override fun executeGetRowsAffected(
         sql: String,
         bindArgs: Array<Any?>?,
-    ): Int {
-        checkMainThreadSQL(sql)
-        return runDbCommandForRowCount(dbRequestJson(sql, bindArgs ?: emptyArray())).toInt()
-    }
+    ): Int = runDbCommandForRowCount(dbRequestJson(sql, bindArgs ?: emptyArray())).toInt()
 
     // Begin Protobuf-based database streaming methods (#6)
     override fun fullQueryProto(
         query: String,
         bindArgs: Array<out Any?>,
-    ): DbResponse {
-        checkMainThreadSQL(query)
-        return runDbCommandProto(dbRequestJson(query, bindArgs))
-    }
+    ): DbResponse = runDbCommandProto(dbRequestJson(query, bindArgs))
 
     override fun getNextSlice(
         startIndex: Long,
@@ -229,65 +213,7 @@ open class Backend(
 
     override fun getColumnNames(sql: String): Array<String> = getColumnNamesFromQuery(sql).toTypedArray()
 
-    private fun checkMainThreadOp(sql: String? = null) {
-        if (!checkOperationsRunOnMainThread) return
-        runIfOnMainThread {
-            val stackTraceElements = Thread.currentThread().stackTrace
-            val firstElem =
-                stackTraceElements
-                    .filter {
-                        val klass = it.className
-                        for (text in listOf(
-                            "rsdroid",
-                            "libanki",
-                            "java.lang",
-                            "dalvik",
-                            "anki.backend",
-                            "DatabaseChangeDecorator",
-                        )) {
-                            if (text in klass) {
-                                return@filter false
-                            }
-                        }
-                        true
-                    }.first()
-            logger.warn("Op on UI thread: {}", firstElem)
-            sql?.let {
-                logger.warn("{}", sql)
-            }
-        }
-    }
-
-    private fun checkMainThreadSQL(query: String) {
-        checkMainThreadOp(query)
-    }
-
-    private fun runIfOnMainThread(func: () -> Unit) {
-        try {
-            if (Looper.getMainLooper().thread == Thread.currentThread()) {
-                func()
-            }
-        } catch (exc: NoSuchMethodError) {
-            // running outside Android, or old API
-        } catch (ex: RuntimeException) {
-            // If running with no Android dependencies, we get the error:
-            // Method getMainLooper in android.os.Looper not mocked.
-            // See https://developer.android.com/r/studio-ui/build/not-mocked for details.
-            // runIfOnMainThread is non-vital, so we can ignore the exception
-            if (ex.message?.contains("android.os.Looper not mocked") == true) {
-                return
-            }
-            throw ex
-        }
-    }
-
     companion object {
-        /**
-         * Debug setting: if true, logs all operations executed on the main thread
-         */
-        // This is false by default: translate() ais an extremely fast operation
-        // which does not require execution on a worker thread
-        var checkOperationsRunOnMainThread: Boolean = false
         const val MAX_MEDIA_FILENAME_LENGTH = 120
 
         const val MAX_MEDIA_FILENAME_LENGTH_SERVER = 255

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendException.kt
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendException.kt
@@ -54,7 +54,7 @@ open class BackendException : RuntimeException {
         return SQLiteException(message, this)
     }
 
-    class BackendDbException(
+    open class BackendDbException(
         error: BackendError,
     ) : BackendException(error) {
         override fun toSQLiteException(query: String): RuntimeException {
@@ -79,11 +79,6 @@ open class BackendException : RuntimeException {
                 }
             } else if (message.contains("ConstraintViolation")) {
                 return SQLiteConstraintException(message)
-            } else if (message.contains("DiskFull")) {
-                return SQLiteFullException(message)
-            } else if (message.contains("DatabaseCorrupt")) {
-                val outMessage = String.format(Locale.ROOT, "error while compiling: \"%s\": %s", query, message)
-                return SQLiteDatabaseCorruptException(outMessage)
             }
             val outMessage = String.format(Locale.ROOT, "error while compiling: \"%s\": %s", query, message)
             return SQLiteException(outMessage, this)
@@ -105,6 +100,21 @@ open class BackendException : RuntimeException {
             error: BackendError,
         ) : BackendException(error)
 
+        /** The disk is full: analogue of android's SQLiteFullException */
+        class BackendDbFullException(
+            error: BackendError,
+        ) : BackendDbException(error) {
+            override fun toSQLiteException(query: String): RuntimeException = SQLiteFullException(localizedMessage)
+        }
+
+        /** The collection database is corrupt: analogue of android's SQLiteDatabaseCorruptException */
+        class BackendDbCorruptException(
+            error: BackendError,
+        ) : BackendDbException(error) {
+            override fun toSQLiteException(query: String): RuntimeException =
+                SQLiteDatabaseCorruptException(String.format(Locale.ROOT, "error while compiling: \"%s\": %s", query, localizedMessage))
+        }
+
         companion object {
             fun fromDbError(error: BackendError): BackendException {
                 val localised = error.message ?: return BackendDbException(error)
@@ -116,6 +126,13 @@ open class BackendException : RuntimeException {
                 }
                 if (localised.contains("kind: MissingEntity")) {
                     return BackendDbMissingEntityException(error)
+                }
+                // checked before "kind: Other": these messages may contain both markers
+                if (localised.contains("DiskFull")) {
+                    return BackendDbFullException(error)
+                }
+                if (localised.contains("DatabaseCorrupt")) {
+                    return BackendDbCorruptException(error)
                 }
                 if (localised.contains("kind: Other")) {
                     return BackendDbException(error)

--- a/rsdroid/src/test/java/net/ankiweb/BackendExceptionTest.kt
+++ b/rsdroid/src/test/java/net/ankiweb/BackendExceptionTest.kt
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package net.ankiweb
+
+import anki.backend.BackendError
+import net.ankiweb.rsdroid.BackendException.BackendDbException
+import net.ankiweb.rsdroid.BackendException.BackendDbException.BackendDbCorruptException
+import net.ankiweb.rsdroid.BackendException.BackendDbException.BackendDbFileTooNewException
+import net.ankiweb.rsdroid.BackendException.BackendDbException.BackendDbFileTooOldException
+import net.ankiweb.rsdroid.BackendException.BackendDbException.BackendDbFullException
+import net.ankiweb.rsdroid.BackendException.BackendDbException.BackendDbLockedException
+import net.ankiweb.rsdroid.BackendException.BackendDbException.BackendDbMissingEntityException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Tests [BackendDbException.fromDbError]: AnkiDroid's startup error handling relies on these types */
+class BackendExceptionTest {
+    @Test
+    fun diskFullIsTyped() {
+        val exception = fromDbError("DbError { info: \"SqliteFailure(Error { code: DiskFull })\", kind: Other }")
+        assertEquals(BackendDbFullException::class.java, exception.javaClass)
+        // existing catch (BackendDbException) sites must still match
+        assertTrue(exception is BackendDbException)
+    }
+
+    @Test
+    fun corruptionIsTyped() {
+        val exception = fromDbError("DbError { info: \"SqliteFailure(Error { code: DatabaseCorrupt })\", kind: Other }")
+        assertEquals(BackendDbCorruptException::class.java, exception.javaClass)
+        assertTrue(exception is BackendDbException)
+    }
+
+    @Test
+    fun fileTooNewIsTyped() {
+        assertEquals(
+            BackendDbFileTooNewException::class.java,
+            fromDbError("DbError { info: \"\", kind: FileTooNew }").javaClass,
+        )
+    }
+
+    @Test
+    fun fileTooOldIsTyped() {
+        assertEquals(
+            BackendDbFileTooOldException::class.java,
+            fromDbError("DbError { info: \"\", kind: FileTooOld }").javaClass,
+        )
+    }
+
+    @Test
+    fun missingEntityIsTyped() {
+        assertEquals(
+            BackendDbMissingEntityException::class.java,
+            fromDbError("DbError { info: \"\", kind: MissingEntity }").javaClass,
+        )
+    }
+
+    @Test
+    fun lockedIsTyped() {
+        assertEquals(
+            BackendDbLockedException::class.java,
+            fromDbError("Anki already open, or media currently syncing.").javaClass,
+        )
+    }
+
+    @Test
+    fun kindOtherWithoutMarkersIsUntyped() {
+        assertEquals(
+            BackendDbException::class.java,
+            fromDbError("DbError { info: \"something else\", kind: Other }").javaClass,
+        )
+    }
+
+    @Test
+    fun unknownMessageIsUntyped() {
+        assertEquals(BackendDbException::class.java, fromDbError("no recognisable marker").javaClass)
+    }
+
+    private fun fromDbError(message: String) =
+        BackendDbException.fromDbError(
+            BackendError
+                .newBuilder()
+                .setKind(BackendError.Kind.DB_ERROR)
+                .setMessage(message)
+                .build(),
+        )
+}

--- a/rsdroid/src/test/java/net/ankiweb/SQLiteExceptionMappingTest.kt
+++ b/rsdroid/src/test/java/net/ankiweb/SQLiteExceptionMappingTest.kt
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package net.ankiweb
+
+import android.database.sqlite.SQLiteConstraintException
+import android.database.sqlite.SQLiteDatabaseCorruptException
+import android.database.sqlite.SQLiteException
+import android.database.sqlite.SQLiteFullException
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import anki.backend.BackendError
+import net.ankiweb.rsdroid.BackendException
+import net.ankiweb.rsdroid.BackendException.BackendDbException
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Tests for [BackendException.toSQLiteException]. */
+@RunWith(AndroidJUnit4::class) // Robolectric - the stub android.jar can't construct the exceptions
+class SQLiteExceptionMappingTest {
+    @Test
+    fun diskFullMapsToSQLiteFullException() {
+        val mapped = fromDbError("DbError { info: \"DiskFull\", kind: Other }").toSQLiteException("select 1")
+        assertEquals(SQLiteFullException::class.java, mapped.javaClass)
+    }
+
+    @Test
+    fun corruptionMapsToSQLiteDatabaseCorruptException() {
+        val message = "DbError { info: \"DatabaseCorrupt\", kind: Other }"
+        val mapped = fromDbError(message).toSQLiteException("select 1")
+        assertEquals(SQLiteDatabaseCorruptException::class.java, mapped.javaClass)
+        assertEquals("error while compiling: \"select 1\": $message", mapped.message)
+    }
+
+    @Test
+    fun constraintViolationMapsToSQLiteConstraintException() {
+        val mapped = fromDbError("ConstraintViolation oops").toSQLiteException("insert into x")
+        assertEquals(SQLiteConstraintException::class.java, mapped.javaClass)
+    }
+
+    @Test
+    fun invalidParameterCountMapsToIllegalArgumentException() {
+        val mapped = fromDbError("InvalidParameterCount(1, 2)").toSQLiteException("select ?")
+        assertEquals(IllegalArgumentException::class.java, mapped.javaClass)
+        assertEquals(
+            "Cannot bind argument at index 1 because the index is out of range.  The statement has 2 parameters.",
+            mapped.message,
+        )
+    }
+
+    @Test
+    fun unknownDbErrorMapsToSQLiteException() {
+        val mapped = fromDbError("something unrecognised").toSQLiteException("select 1")
+        assertEquals(SQLiteException::class.java, mapped.javaClass)
+        assertEquals("error while compiling: \"select 1\": something unrecognised", mapped.message)
+    }
+
+    @Test
+    fun nonDbBackendExceptionMapsToSQLiteException() {
+        val mapped = BackendException("boom").toSQLiteException("select 1")
+        assertEquals(SQLiteException::class.java, mapped.javaClass)
+        assertEquals("error while compiling: \"select 1\": boom", mapped.message)
+    }
+
+    private fun fromDbError(message: String) =
+        BackendDbException.fromDbError(
+            BackendError
+                .newBuilder()
+                .setKind(BackendError.Kind.DB_ERROR)
+                .setMessage(message)
+                .build(),
+        )
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

Another set of extractions so we can move to a `java-library`

----

Recoding the main thread check using Reflection was possible, but it hasn't been triggered in years, and is effectively dead code now we have CollectionManager