### PR TITLE
build: bump version to 0.1.67-anki26.05

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 GROUP=io.github.david-allison
-VERSION_NAME=0.1.66-anki26.05
+VERSION_NAME=0.1.67-anki26.05
 
 POM_INCEPTION_YEAR=2020
 


### PR DESCRIPTION
Primarily: a4a513375f2ac8c1da8ec871209ce6542b861065
 - adds strongly typed backend exceptions so Anki-Android can move to these before removing an android SQLite dependency (when we move the backend to `java-library`)
 - Fixes use-after-free bug causing macOS test failures also:
 - removes `Backend.checkOperationsRunOnMainThread`
 - dependencies:
   - protobuf-kotlin-lite 4.36.1
   - slf4j-api 1.7.36
     - replacing Timber
   - androidx.sqlite 2.7.0


https://github.com/ankidroid/Anki-Android-Backend/compare/307254b48406c012373030e3454703ea135b643c...fc23f690a770463ded45174c1150a81ea7601169